### PR TITLE
feat: Add single LLM evaluation script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "start": "ts-node src/index.ts",
+    "single-eval": "ts-node src/singleAgentEval.ts",
     "test": "jest"
   },
   "keywords": [],

--- a/src/singleAgentEval.ts
+++ b/src/singleAgentEval.ts
@@ -1,0 +1,29 @@
+import { runEnsemble } from './agent';
+
+async function main() {
+  const args = process.argv.slice(2);
+  const userPrompt = args[0];
+  const model = args[1] || 'llama3:8b'; // Default to llama3:8b if not provided
+
+  if (!userPrompt) {
+    console.error('Usage: ts-node src/singleAgentEval.ts <your_prompt> [model]');
+    process.exit(1);
+  }
+
+  console.log(`Running single agent evaluation for prompt: "${userPrompt}"`);
+  console.log(`Using model: ${model}`);
+
+  try {
+    const results = await runEnsemble(userPrompt, [model]);
+    console.log('\n--- Single Agent Result ---');
+    if (results.length > 0) {
+      console.log(`Model ${model}:\n${results[0]}\n`);
+    } else {
+      console.log('No response from the model.');
+    }
+  } catch (error) {
+    console.error('An error occurred during single agent evaluation:', error);
+  }
+}
+
+main();


### PR DESCRIPTION
単体LLM評価用のスクリプト `src/singleAgentEval.ts` を追加しました。

これにより、`npm run single-eval "プロンプト" [モデル名]` コマンドで単体LLMの評価を簡単に行えるようになります。