### PR TITLE
docs: Add generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,10 @@ dist/
 *.swp
 .git_commit_message.txt
 local.prompts.md
+
+# Blind Evaluation Outputs and Discussion Logs
+doc/blind_evaluation/
+
+# Talk Documents
+doc/design_talk/
+doc/mvp_talk/


### PR DESCRIPTION
This commit adds generated files and directories to .gitignore to prevent them from being tracked by Git.

Affected files/directories:
- doc/blind_evaluation/
- doc/design_talk/
- doc/mvp_talk/