### PR TITLE
feat: プロンプト読み込み機能の単体テストの実装

### DIFF
--- a/src/__tests__/promptLoader.test.ts
+++ b/src/__tests__/promptLoader.test.ts
@@ -12,9 +12,7 @@ describe('loadPromptFile', () => {
 
   beforeAll(() => {
     // テスト用ディレクトリの作成
-    if (!fs.existsSync(testPromptsDir)) {
-      fs.mkdirSync(testPromptsDir);
-    }
+    fs.mkdirSync(testPromptsDir, { recursive: true });
 
     // 有効なプロンプトファイル
     fs.writeFileSync(validPromptFilePath, JSON.stringify({
@@ -43,9 +41,9 @@ describe('loadPromptFile', () => {
     }, null, 2));
   });
 
-  afterAll(() => {
+  afterAll(async () => {
     // テスト用ディレクトリの削除
-    fs.rmSync(testPromptsDir, { recursive: true, force: true });
+    await fs.promises.rm(testPromptsDir, { recursive: true, force: true });
   });
 
   it('should load a valid prompt file successfully', async () => {


### PR DESCRIPTION
レビューコメントに基づき、`src/__tests__/promptLoader.test.ts` におけるファイル操作をより安全な方法に修正しました。

- `fs.rmSync` を `fs.promises.rm` に変更し、`afterAll` を `async` に修正。
- `fs.existsSync` と `fs.mkdirSync` の組み合わせを `fs.mkdirSync(testPromptsDir, { recursive: true })` に変更。