### PR TITLE
feat: 設定ファイルを読み込むユーティリティ関数の実装

### DIFF
--- a/src/utils/configLoader.ts
+++ b/src/utils/configLoader.ts
@@ -1,0 +1,47 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+// 設定ファイル全体の型
+export interface ConfigContent {
+  prompt_file_path: string;
+}
+
+/**
+ * 指定されたパスのJSON形式の設定ファイルを読み込み、パースして返す。
+ *
+ * @param filePath 設定ファイルの絶対パス
+ * @returns Promise<ConfigContent> 設定ファイルの内容
+ * @throws Error ファイルが見つからない、JSON形式が不正、スキーマが不正な場合
+ */
+export async function loadConfigFile(filePath: string): Promise<ConfigContent> {
+  try {
+    // ファイルの存在チェック
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`Config file not found: ${filePath}`);
+    }
+
+    // ファイルの読み込み
+    const fileContent = await fs.promises.readFile(filePath, 'utf8');
+
+    // JSONパース
+    let parsedContent: any;
+    try {
+      parsedContent = JSON.parse(fileContent);
+    } catch (jsonError) {
+      throw new Error(`Invalid JSON format in ${filePath}: ${jsonError.message}`);
+    }
+
+    // スキーマ検証
+    if (
+      typeof parsedContent.prompt_file_path !== 'string'
+    ) {
+      throw new Error(`Invalid schema in ${filePath}: Missing prompt_file_path.`);
+    }
+
+    return parsedContent as ConfigContent;
+
+  } catch (error) {
+    // エラーを再スロー
+    throw error;
+  }
+}


### PR DESCRIPTION
指定されたパスのJSON形式の設定ファイルを読み込み、パースして、アプリケーションで利用可能なオブジェクト形式で返すユーティリティ関数 `loadConfigFile` を `src/utils/configLoader.ts` に実装しました。

これは、プロンプト管理機能の要件定義 (REQ-PM-008) に対応し、設定を動的にロードできるようにするものです。