### PR TITLE
refactor: エラーハンドリングロジックの共通化

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { conductConsultation } from './agent';
 import { loadPromptFile, PromptFileContent } from './utils/promptLoader';
 import { loadConfigFile, ConfigContent } from './utils/configLoader';
+import { getErrorMessage } from './utils/errorUtils';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import * as path from 'path';
@@ -35,10 +36,7 @@ async function main() {
       prompts = await loadPromptFile(promptFilePath);
       console.log(`Loaded prompts from config file: ${configFilePath}`);
     } catch (error) {
-      const errorMsg = (error && typeof error === 'object' && typeof (error as any).message === 'string')
-        ? (error as any).message
-        : String(error);
-      console.error(`Error loading configuration or prompt file: ${errorMsg}`);
+      console.error(`Error loading configuration or prompt file: ${getErrorMessage(error)}`);
       process.exit(1);
     }
   } else {
@@ -48,10 +46,7 @@ async function main() {
       prompts = await loadPromptFile(defaultPromptFilePath);
       console.log(`No config file specified. Loaded default prompts from: ${defaultPromptFilePath}`);
     } catch (error) {
-      const errorMsg = (error && typeof error === 'object' && typeof (error as any).message === 'string')
-        ? (error as any).message
-        : String(error);
-      console.error(`Error loading default prompt file: ${errorMsg}`);
+      console.error(`Error loading default prompt file: ${getErrorMessage(error)}`);
       process.exit(1);
     }
   }
@@ -62,7 +57,7 @@ async function main() {
     console.log('\n--- Final Consultation Result ---');
     console.log(result);
   } catch (error) {
-    console.error('An error occurred during consultation:', error);
+    console.error('An error occurred during consultation:', getErrorMessage(error));
   }
 }
 

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -1,0 +1,13 @@
+/**
+ * エラーオブジェクトから安全にエラーメッセージを取得する。
+ * errorがErrorインスタンスでない場合でも、ランタイムエラーが発生しないようにする。
+ *
+ * @param error エラーオブジェクト
+ * @returns エラーメッセージ文字列
+ */
+export function getErrorMessage(error: unknown): string {
+  if (error && typeof error === 'object' && typeof (error as any).message === 'string') {
+    return (error as any).message;
+  }
+  return String(error);
+}

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -6,8 +6,8 @@
  * @returns エラーメッセージ文字列
  */
 export function getErrorMessage(error: unknown): string {
-  if (error && typeof error === 'object' && typeof (error as any).message === 'string') {
-    return (error as any).message;
+  if (error instanceof Error) {
+    return error.message;
   }
   return String(error);
 }


### PR DESCRIPTION
レビューコメントに基づき、`src/utils/errorUtils.ts` の `getErrorMessage` 関数において、型安全性を向上させました。`error instanceof Error` を使用することで、より安全で読みやすいコードになっています。