### PR TITLE
feat: src/prompts.tsからハードコードされたプロンプトの削除

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ async function main() {
 
   try {
     // conductConsultation のシグネチャ変更が必要
-    const result = await conductConsultation(userPrompt, model1, model2 /*, prompts */);
+    const result = await conductConsultation(userPrompt, model1, model2, prompts);
     console.log('\n--- Final Consultation Result ---');
     console.log(result);
   } catch (error) {


### PR DESCRIPTION
`src/prompts.ts` からハードコードされたシステムプロンプトの定義を削除し、`src/agent.ts` と `src/index.ts` で外部ファイルからロードされたプロンプトを使用するように修正しました。

これにより、プロンプトの外部化要件 (REQ-PM-001) を完全に満たします。