### PR TITLE
feat: main_evaluation.pyの出力パスにタイムスタンプを追加

### DIFF
--- a/scripts/generate_evaluation_prompts.py
+++ b/scripts/generate_evaluation_prompts.py
@@ -4,8 +4,17 @@ import json
 import random
 from prompts_config import SCENARIOS
 
-OUTPUT_DIR = "eval/model_comparison/outputs/"
-RECORDS_DIR = "eval/model_comparison/records/"
+def get_base_dir():
+    try:
+        with open("eval/model_comparison/current_run_base_dir.txt", "r") as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        print("Error: current_run_base_dir.txt not found. Run prepare_evaluation.py first.")
+        exit(1)
+
+BASE_DIR = get_base_dir()
+OUTPUT_DIR = os.path.join(BASE_DIR, "outputs")
+RECORDS_DIR = os.path.join(BASE_DIR, "records")
 MAPPING_FILE = os.path.join(RECORDS_DIR, "mapping.json")
 
 # Scenario prompts (from prompts_config.py)

--- a/scripts/generate_mapping.py
+++ b/scripts/generate_mapping.py
@@ -2,8 +2,17 @@ import os
 import json
 import re
 
-OUTPUT_DIR = "doc/blind_evaluation/outputs/"
-RECORDS_DIR = "doc/blind_evaluation/records/"
+def get_base_dir():
+    try:
+        with open("eval/model_comparison/current_run_base_dir.txt", "r") as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        print("Error: current_run_base_dir.txt not found. Run prepare_evaluation.py first.")
+        exit(1)
+
+BASE_DIR = get_base_dir()
+OUTPUT_DIR = os.path.join(BASE_DIR, "outputs")
+RECORDS_DIR = os.path.join(BASE_DIR, "records")
 MAPPING_FILE = os.path.join(RECORDS_DIR, "mapping.json")
 
 def generate_mapping():

--- a/scripts/generate_reports.py
+++ b/scripts/generate_reports.py
@@ -2,8 +2,17 @@ import subprocess
 import os
 from prompts_config import SCENARIOS
 
-OUTPUT_DIR = "doc/blind_evaluation/outputs/"
-RECORDS_DIR = "doc/blind_evaluation/records/"
+def get_base_dir():
+    try:
+        with open("eval/model_comparison/current_run_base_dir.txt", "r") as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        print("Error: current_run_base_dir.txt not found. Run prepare_evaluation.py first.")
+        exit(1)
+
+BASE_DIR = get_base_dir()
+OUTPUT_DIR = os.path.join(BASE_DIR, "outputs")
+RECORDS_DIR = os.path.join(BASE_DIR, "records")
 
 def run_command(cmd, output_file, discussion_log_file=None):
     print(f"Running command: {' '.join(cmd)}")

--- a/scripts/prepare_evaluation.py
+++ b/scripts/prepare_evaluation.py
@@ -1,19 +1,26 @@
 import os
 import shutil
-
-OUTPUT_DIR = "eval/model_comparison/outputs/"
-RECORDS_DIR = "eval/model_comparison/records/"
+from datetime import datetime
 
 def prepare_evaluation():
+    timestamp = datetime.now().strftime("%Y%m%d%H%M")
+    base_dir = os.path.join("eval/model_comparison", timestamp)
+    
+    OUTPUT_DIR = os.path.join(base_dir, "outputs")
+    RECORDS_DIR = os.path.join(base_dir, "records")
+
     print("--- 出力ディレクトリをクリーンアップ中 ---")
-    if os.path.exists(OUTPUT_DIR):
-        shutil.rmtree(OUTPUT_DIR)
-    if os.path.exists(RECORDS_DIR):
-        shutil.rmtree(RECORDS_DIR)
+    # If the base_dir already exists from a previous run with the same timestamp, remove it.
+    if os.path.exists(base_dir):
+        shutil.rmtree(base_dir)
 
     os.makedirs(OUTPUT_DIR, exist_ok=True)
     os.makedirs(RECORDS_DIR, exist_ok=True)
-    print("--- 出力ディレクトリのクリーンアップと作成が完了しました ---")
+    print(f"--- 出力ディレクトリのクリーンアップと作成が完了しました: {base_dir} ---")
+    
+    # Save the base_dir to a temporary file for other scripts to use
+    with open("eval/model_comparison/current_run_base_dir.txt", "w") as f:
+        f.write(base_dir)
 
 if __name__ == "__main__":
     prepare_evaluation()


### PR DESCRIPTION
main_evaluation.pyの実行時に生成される出力ディレクトリにタイムスタンプを追加しました。これにより、過去の実行結果が上書きされるのを防ぎ、管理しやすくなります。