### PR TITLE
feat: LLMエージェント協調プロセスの柔軟化

### DIFF
--- a/config/workflow_config.json
+++ b/config/workflow_config.json
@@ -1,0 +1,71 @@
+{
+  "workflows": {
+    "code_review_and_refactor": {
+      "description": "ユーザーからコードを受け取り、コードレビューエージェントがレビューし、そのフィードバックに基づいてリファクタリングエージェントがコードを修正します。",
+      "initial_step": "review_step",
+      "steps": [
+        {
+          "id": "review_step",
+          "type": "agent_interaction",
+          "agent_id": "reviewer_agent",
+          "prompt_id": "REVIEWER_PROMPT_TEMPLATE",
+          "input_variables": {
+            "userPrompt": "user_input",
+            "lastThinkerImproverResponse": "user_input"
+          },
+          "output_variable": "review_feedback",
+          "next_step": "improver_step"
+        },
+        {
+          "id": "improver_step",
+          "type": "agent_interaction",
+          "agent_id": "thinker_improver_agent",
+          "prompt_id": "IMPROVER_PROMPT_TEMPLATE",
+          "input_variables": {
+            "userPrompt": "user_input",
+            "lastReviewerResponse": "review_feedback",
+            "lastThinkerImproverResponse": "user_input"
+          },
+          "output_variable": "refactored_code",
+          "next_step": "end"
+        }
+      ]
+    },
+    "parallel_qa_and_summarize": {
+      "description": "複数のエージェントが独立して同じ質問に回答し、その回答を要約エージェントが統合します。",
+      "initial_step": "parallel_qa_step",
+      "steps": [
+        {
+          "id": "parallel_qa_step",
+          "type": "multi_agent_interaction",
+          "agents_to_run": [
+            {
+              "agent_id": "qa_agent_1",
+              "prompt_id": "answer_question_prompt",
+              "input_variables": { "question": "user_input" },
+              "output_variable": "answer_1"
+            },
+            {
+              "agent_id": "qa_agent_2",
+              "prompt_id": "answer_question_prompt",
+              "input_variables": { "question": "user_input" },
+              "output_variable": "answer_2"
+            }
+          ],
+          "next_step": "summarize_answers_step"
+        },
+        {
+          "id": "summarize_answers_step",
+          "type": "agent_interaction",
+          "agent_id": "summarizer_agent",
+          "prompt_id": "SUMMARIZER_SYSTEM_PROMPT",
+          "input_variables": {
+            "answers": "answer_1\n\nanswer_2" 
+          },
+          "output_variable": "final_summary",
+          "next_step": "end"
+        }
+      ]
+    }
+  }
+}

--- a/doc/llm_agent_coordination_flexibility_requirements_refined.md
+++ b/doc/llm_agent_coordination_flexibility_requirements_refined.md
@@ -1,0 +1,120 @@
+# LLMエージェント協調プロセス柔軟化要件定義 (簡易版)
+
+## 1. 目的
+
+LLMエージェント間の協調プロセスを、コードの変更なしに外部設定で柔軟に定義・変更できるようにする。特に、プロンプトセットの切り替えによる役割変更と、ブースティング型・バギング型のフロー実現に焦点を当てる。
+
+## 2. スコープ
+
+*   エージェントの役割定義の外部化（プロンプトセットの切り替えを含む）。
+*   エージェント間の対話フローの外部化（逐次実行、複数エージェントによる独立処理と統合）。
+*   `src/agent.ts` のプロセス知識からの分離。
+
+## 3. 機能要件
+
+### 3.1. ロール定義の外部化とプロンプトセットの切り替え
+
+*   各エージェントの役割（システムプロンプト、IDなど）を**プロンプト定義ファイル**（例: `prompts/default_prompts.json`）で定義できること。
+*   `src/agent.ts` は、定義されたロールIDに基づいてエージェントをインスタンス化できること。
+*   フロー定義内で、エージェントが使用する**プロンプトID**を指定することで、エージェントの振る舞い（プロンプトセット）を切り替えられること。
+
+### 3.2. 対話フローの外部化
+
+エージェント間の対話の順序、各ステップで使用するプロンプトID、次のステップへの遷移などを、外部設定ファイル（例: `config/workflow_config.json`）で定義できること。
+
+#### 3.2.1. ブースティング型フロー (逐次実行)
+
+*   あるエージェントの出力が、次のエージェントの入力となるような逐次的な対話フローを定義できること。
+
+#### 3.2.2. バギング型フロー (複数エージェントによる独立処理と統合)
+
+*   同じ入力に対して複数のエージェントが独立して処理を行い、その結果を後続のステップで統合するフローを定義できること。
+
+### 3.3. プロンプトの参照
+
+*   フロー定義内で、**プロンプト定義ファイル**に定義されたプロンプトIDを参照できること。
+
+## 4. 非機能要件
+
+*   **柔軟性**: コードの変更なしに、新しいロールや対話フローを容易に追加・変更できること。
+*   **保守性**: プロセスロジックとプロンプト定義が分離されることで、コードの保守性が向上すること。
+*   **パフォーマンス**: 外部設定の読み込みによる顕著なパフォーマンス劣化がないこと。
+
+## 5. 実装対象ファイル
+
+*   `src/agent.ts` (コアロジックの変更)
+*   `src/index.ts` (設定ファイルの読み込み、`src/agent.ts` への連携)
+*   **プロンプト定義ファイル**（例: `prompts/default_prompts.json`）(ロール定義の追加)
+*   新規設定ファイル（例: `config/workflow_config.json`）
+
+## 6. フロー定義の簡易スキーマ案
+
+### 6.1. `prompts/default_prompts.json` への追加要素
+
+```json
+{
+  "agent_roles": {
+    "agent_id_example": {
+      "system_prompt": "エージェントのシステムプロンプト",
+      "description": "エージェントの役割説明",
+      "model": "ollama:llama3" // オプション: このエージェントが使用するLLMモデル
+    }
+  }
+}
+```
+
+### 6.2. `config/workflow_config.json` のスキーマ案
+
+```json
+{
+  "workflows": {
+    "workflow_name_example": {
+      "description": "ワークフローの説明",
+      "initial_step": "step_id_start",
+      "steps": [
+        {
+          "id": "step_id_start",
+          "type": "agent_interaction", // 単一エージェントとの対話
+          "agent_id": "agent_id_example",
+          "prompt_id": "prompt_id_example",
+          "input_variables": {
+            "variable_name": "source_of_value" // "user_input" または 前のステップのoutput_variable
+          },
+          "output_variable": "output_variable_name",
+          "next_step": "next_step_id" // または "end"
+        },
+        {
+          "id": "multi_agent_example_step",
+          "type": "multi_agent_interaction", // 複数エージェントによる独立処理
+          "agents_to_run": [
+            {
+              "agent_id": "agent_A",
+              "prompt_id": "prompt_for_A",
+              "input_variables": { "data": "user_input" },
+              "output_variable": "output_A"
+            },
+            {
+              "agent_id": "agent_B",
+              "prompt_id": "prompt_for_B",
+              "input_variables": { "data": "user_input" },
+              "output_variable": "output_B"
+            }
+          ],
+          "next_step": "aggregation_step"
+        },
+        {
+          "id": "aggregation_step",
+          "type": "agent_interaction",
+          "agent_id": "aggregator_agent",
+          "prompt_id": "aggregation_prompt",
+          "input_variables": {
+            "result_A": "output_A",
+            "result_B": "output_B"
+          },
+          "output_variable": "final_aggregated_result",
+          "next_step": "end"
+        }
+      ]
+    }
+  }
+}

--- a/prompts/default_prompts.json
+++ b/prompts/default_prompts.json
@@ -35,6 +35,54 @@
       "id": "FINAL_REPORT_TEMPLATE",
       "description": "最終レポートのテンプレート",
       "content": "以下のレポートテンプレートの各セクションを、提供された「最終改善案」の内容に基づいて埋めてください。レポートとして自然な文章になるように、あなた自身の言葉で記述し直してください。\n\n---\n**レポートテンプレート**\n\n#（ここにレポートのタイトルを記述）\n\n## 1. はじめに\n（ここに導入・目的を記述）\n\n## 2. 課題の分析\n（ここに議論された課題を記述）\n\n## 3. 解決策の提案\n（ここに議論された解決策を記述）\n\n## 4. 結論\n（ここに結論を記述）\n---\n\n**情報ソース（この内容を使って上記テンプレートを埋めること）**\n\nユーザープロンプト: ${userPrompt}\n最終改善案: ${finalAnswer}"
+    },
+    {
+      "id": "answer_question_prompt",
+      "description": "質問応答エージェントのプロンプトテンプレート",
+      "content": "以下の質問に答えてください: {{question}}"
     }
-  ]
+  ],
+  "agent_roles": {
+    "thinker_improver_agent": {
+      "system_prompt_id": "THINKER_IMPROVER_SYSTEM_PROMPT",
+      "description": "思考者・指摘改善者エージェント",
+      "model": "ollama:llama3"
+    },
+    "reviewer_agent": {
+      "system_prompt_id": "REVIEWER_SYSTEM_PROMPT",
+      "description": "批判的レビュアーエージェント",
+      "model": "ollama:llama3"
+    },
+    "summarizer_agent": {
+      "system_prompt_id": "SUMMARIZER_SYSTEM_PROMPT",
+      "description": "要約者エージェント",
+      "model": "ollama:llama3"
+    },
+    "qa_agent_1": {
+      "system_prompt_id": "SUMMARIZER_SYSTEM_PROMPT",
+      "description": "質問応答エージェント1",
+      "model": "ollama:llama3"
+    },
+    "qa_agent_2": {
+      "system_prompt_id": "SUMMARIZER_SYSTEM_PROMPT",
+      "description": "質問応答エージェント2",
+      "model": "ollama:llama3"
+    }
+  }
+    "thinker_improver_agent": {
+      "system_prompt_id": "THINKER_IMPROVER_SYSTEM_PROMPT",
+      "description": "思考者・指摘改善者エージェント",
+      "model": "ollama:llama3"
+    },
+    "reviewer_agent": {
+      "system_prompt_id": "REVIEWER_SYSTEM_PROMPT",
+      "description": "批判的レビュアーエージェント",
+      "model": "ollama:llama3"
+    },
+    "summarizer_agent": {
+      "system_prompt_id": "SUMMARIZER_SYSTEM_PROMPT",
+      "description": "要約者エージェント",
+      "model": "ollama:llama3"
+    }
+  }
 }

--- a/src/utils/promptLoader.ts
+++ b/src/utils/promptLoader.ts
@@ -9,9 +9,18 @@ export interface PromptDefinition {
 }
 
 // プロンプトファイル全体の型
+export interface AgentRoleDefinition {
+  system_prompt_id: string;
+  description: string;
+  model: string;
+  temperature?: number;
+}
+
+// プロンプトファイル全体の型
 export interface PromptFileContent {
   format_version: string;
   prompts: PromptDefinition[];
+  agent_roles?: { [key: string]: AgentRoleDefinition }; // agent_rolesを追加
 }
 
 /**
@@ -74,4 +83,21 @@ export async function loadPromptFile(filePath: string): Promise<PromptFileConten
  */
 export function getPromptById(prompts: PromptDefinition[], id: string): PromptDefinition | undefined {
   return prompts.find(prompt => prompt.id === id);
+}
+
+/**
+ * エージェントロールIDに基づいて特定のエージェントロール定義を検索する。
+ *
+ * @param agentRoles エージェントロール定義のマップ
+ * @param id 検索するエージェントロールのID
+ * @returns AgentRoleDefinition | undefined 見つかったエージェントロール定義、またはundefined
+ */
+export function getAgentRoleById(
+  agentRoles: { [key: string]: AgentRoleDefinition } | undefined,
+  id: string
+): AgentRoleDefinition | undefined {
+  if (!agentRoles) {
+    return undefined;
+  }
+  return agentRoles[id];
 }

--- a/src/utils/workflowLoader.ts
+++ b/src/utils/workflowLoader.ts
@@ -1,0 +1,70 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface InputVariable {
+  [key: string]: string; // 例: "userPrompt": "user_input", "feedback": "review_feedback"
+}
+
+export interface AgentInteractionStep {
+  id: string;
+  type: "agent_interaction";
+  agent_id: string;
+  prompt_id: string;
+  input_variables: InputVariable;
+  output_variable?: string;
+  next_step: string; // ステップID または "end"
+}
+
+export interface MultiAgentInteractionBranch {
+  agent_id: string;
+  prompt_id: string;
+  input_variables: InputVariable;
+  output_variable?: string;
+}
+
+export interface MultiAgentInteractionStep {
+  id: string;
+  type: "multi_agent_interaction";
+  agents_to_run: MultiAgentInteractionBranch[];
+  next_step: string; // ステップID または "end"
+}
+
+export type WorkflowStep = AgentInteractionStep | MultiAgentInteractionStep;
+
+export interface WorkflowDefinition {
+  description: string;
+  initial_step: string;
+  steps: WorkflowStep[];
+}
+
+export interface WorkflowConfigFileContent {
+  workflows: {
+    [key: string]: WorkflowDefinition;
+  };
+}
+
+export async function loadWorkflowFile(filePath: string): Promise<WorkflowConfigFileContent> {
+  try {
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`Workflow file not found: ${filePath}`);
+    }
+
+    const fileContent = fs.readFileSync(filePath, 'utf8');
+    let parsedContent: any;
+    try {
+      parsedContent = JSON.parse(fileContent);
+    } catch (jsonError) {
+      throw new Error(`Invalid JSON format in ${filePath}: ${String(jsonError)}`);
+    }
+
+    // 基本的なスキーマ検証 (拡張可能)
+    if (typeof parsedContent.workflows !== 'object' || parsedContent.workflows === null) {
+      throw new Error(`Invalid schema in ${filePath}: Missing 'workflows' object.`);
+    }
+
+    return parsedContent as WorkflowConfigFileContent;
+
+  } catch (error) {
+    throw error;
+  }
+}


### PR DESCRIPTION
- エージェントの役割定義をprompts/default_prompts.jsonに外部化
- 対話フロー定義をconfig/workflow_config.jsonに外部化
- src/agent.tsをリファクタリングし、外部定義されたフローをオーケストレーションするorchestrateWorkflow関数を実装
- src/index.tsを更新し、外部定義されたワークフローを実行できるように変更
- src/utils/promptLoader.tsにAgentRoleDefinitionとgetAgentRoleByIdを追加
- src/utils/workflowLoader.tsを新規作成し、ワークフロー定義のインターフェースとローダーを実装