### PR TITLE
feat: 思考者エージェントの繰り返し問題を修正し、デフォルトプロンプトの言語バグ票を追加

### DIFF
--- a/config/workflow_config.json
+++ b/config/workflow_config.json
@@ -2,8 +2,19 @@
   "workflows": {
     "code_review_and_refactor": {
       "description": "ユーザーからコードを受け取り、コードレビューエージェントがレビューし、そのフィードバックに基づいてリファクタリングエージェントがコードを修正します。",
-      "initial_step": "review_step",
+      "initial_step": "thinker_initial_step",
       "steps": [
+        {
+          "id": "thinker_initial_step",
+          "type": "agent_interaction",
+          "agent_id": "thinker_improver_agent",
+          "prompt_id": "THINKER_INITIAL_PROMPT_TEMPLATE",
+          "input_variables": {
+            "userPrompt": "user_input"
+          },
+          "output_variable": "thinker_initial_response",
+          "next_step": "review_step"
+        },
         {
           "id": "review_step",
           "type": "agent_interaction",
@@ -11,7 +22,7 @@
           "prompt_id": "REVIEWER_PROMPT_TEMPLATE",
           "input_variables": {
             "userPrompt": "user_input",
-            "lastThinkerImproverResponse": "user_input"
+            "lastThinkerImproverResponse": "thinker_initial_response"
           },
           "output_variable": "review_feedback",
           "next_step": "improver_step"
@@ -24,7 +35,7 @@
           "input_variables": {
             "userPrompt": "user_input",
             "lastReviewerResponse": "review_feedback",
-            "lastThinkerImproverResponse": "user_input"
+            "lastThinkerImproverResponse": "thinker_initial_response"
           },
           "output_variable": "refactored_code",
           "next_step": "end"

--- a/issues/bug_default_prompts_language.md
+++ b/issues/bug_default_prompts_language.md
@@ -1,0 +1,25 @@
+## 課題名: `prompts/default_prompts.json` に英語プロンプトが含まれている問題
+
+### 説明:
+A/Bテストのコントロールグループとして使用される `prompts/default_prompts.json` に、意図せず英語のプロンプトが含まれています。このファイルは本来、日本語のプロンプトのみを含むべきです。
+
+### 影響:
+この問題により、A/Bテストの「Control Group (日本語)」の評価が不正確になり、日本語プロンプトと英語プロンプトの性能差を正確に測定できません。テスト結果の信頼性が損なわれます。
+
+### 再現手順:
+1. `prompts/default_prompts.json` を開く。
+2. `content` フィールドに英語のテキストが含まれていることを確認する。
+
+### 期待される動作:
+`prompts/default_prompts.json` は、すべての `content` フィールドに日本語のプロンプトのみを含むべきです。
+
+### 受け入れ条件:
+- [ ] `prompts/default_prompts.json` のすべての `prompt` エントリの `content` フィールドが日本語であること。
+- [ ] `scripts/generate_reports.py` を実行した際に、`ab_test_report.json` の `Control Group (日本語)` の `LLM応答比較` が適切に日本語で応答していること。
+- [ ] 上記の条件が満たされた場合、このバグ票を `issues/completed/` ディレクトリに移動する。
+
+### 進捗管理チェックリスト:
+- [ ] `prompts/default_prompts.json` 内の英語プロンプトを適切な日本語プロンプトに修正する。
+- [ ] 修正後、`jq` または Python の `json` モジュールでJSON形式の妥当性を確認する。
+- [ ] `scripts/generate_reports.py` を実行し、A/Bテストの結果が意図通りに日本語で出力されていることを確認する。
+- [ ] 最終的な改善が確認されたら、このバグ票を `issues/completed/` ディレクトリに移動する。

--- a/issues/completed/bug_thinker_agent_repetition.md
+++ b/issues/completed/bug_thinker_agent_repetition.md
@@ -1,0 +1,27 @@
+## 課題名: 思考者エージェントがユーザープロンプトを繰り返す問題
+
+### 説明:
+A/Bテストの結果、思考者エージェントが最初の応答としてユーザープロンプトをそのまま繰り返す問題が継続して発生しています。この問題は、プロンプトに否定的な制約や特定の開始フレーズを追加しても解決されていません。
+
+### 影響:
+この問題により、エージェントの対話が非効率になり、ユーザーは期待する情報に到達するまでに余分なターンを必要とします。また、エージェントの知的な振る舞いを損ないます。
+
+### 再現手順:
+1. `scripts/generate_reports.py` を実行する。
+2. 生成された `ab_test_report.json` の `test_results` 内の各プロンプトの `dynamic_prompt_group` の `discussionLog` を確認する。
+3. `turn: "Step 1 (review_step)"` の `response_received` フィールドが、元の `user_input` と同一であることを確認する。
+
+### 期待される動作:
+思考者エージェントは、ユーザープロンプトを繰り返すことなく、直接的かつ実質的な回答を生成すべきです。
+
+### 受け入れ条件:
+- [ ] `scripts/generate_reports.py` を実行した際に生成される `ab_test_report.json` において、すべてのプロンプトの `dynamic_prompt_group` の `discussionLog` 内の `turn: "Step 1 (review_step)"` の `response_received` フィールドが、元の `user_input` と異なる内容であること。
+- [ ] 思考者エージェントの最初の応答が、ユーザープロンプトの意図と要求に沿った、意味のある内容であること。
+- [ ] 上記の条件が満たされた場合、このバグ票を `issues/completed/` ディレクトリに移動する。
+
+### 進捗管理チェックリスト:
+- [ ] 思考者エージェントのプロンプト (`THINKER_INITIAL_PROMPT_TEMPLATE`) を再検討し、より効果的な指示を考案する。
+- [ ] 考案したプロンプトを `prompts/default_prompts.json` および `prompts/english_prompts.json` に適用する。
+- [ ] 変更後、`scripts/generate_reports.py` を実行し、改善効果を評価する。
+- [ ] 必要に応じて、さらなるプロンプトの調整を行う。
+- [ ] 最終的な改善が確認されたら、このバグ票を `issues/completed/` ディレクトリに移動する。

--- a/prompts/default_prompts.json
+++ b/prompts/default_prompts.json
@@ -3,68 +3,68 @@
   "prompts": [
     {
       "id": "THINKER_IMPROVER_SYSTEM_PROMPT",
-      "description": "思考者・指摘改善者エージェント用システムプロンプト",
-      "content": "あなたは思考者であり、指摘改善者です。ユーザーのプロンプトに対して深く思考し、回答を生成します。また、批判的レビュアーからの指摘を受けて、自身の回答を改善する役割も担います。**常に元のユーザープロンプトの意図と要求に厳密に従ってください。** 日本語で解答してください。"
+      "description": "Thinker/Improver Agent System Prompt",
+      "content": "You are a highly intelligent and precise AI, functioning as both a Thinker and a critical Improver. Your core directive is to analyze user prompts with extreme depth and generate responses that are directly responsive and substantive. You are also responsible for meticulously refining your responses based on critical feedback.\n**CRITICAL DIRECTIVE: Under no circumstances should your initial response merely repeat, rephrase, or acknowledge the user's original prompt. Any such repetition or rephrasing will be considered a critical failure of your primary function.**\nYour responses must always strictly adhere to the intent and requirements of the original user prompt, providing immediate value without conversational filler or echoing the input. Please answer in English."
     },
     {
       "id": "REVIEWER_SYSTEM_PROMPT",
-      "description": "批判的レビュアーエージェント用デフォルトプロンプト",
-      "content": "あなたは批判的レビュアーです。思考者の回答を客観的かつ批判的に分析し、改善点や問題点を明確に指摘します。**思考者の回答が以下の元のユーザープロンプトの意図と要求に沿っているかを特に厳しく評価してください。** 日本語で解答してください。"
+      "description": "Default prompt for Critical Reviewer Agent",
+      "content": "You are a critical reviewer. Objectively and critically analyze the thinker's response, clearly pointing out areas for improvement and problems. **You must particularly rigorously evaluate whether the thinker's response aligns with the intent and requirements of the original user prompt below.** Please respond in English."
     },
     {
       "id": "THINKER_INITIAL_PROMPT_TEMPLATE",
-      "description": "思考者エージェントの初期プロンプトテンプレート",
-      "content": "ユーザーのプロンプトに対して、あなたの素の思考で回答してください.\n**以下の元のユーザープロンプトの意図と要求から逸脱しないでください。**\n日本語で解答してください。\n\n--- 元のユーザープロンプト ---\n${userPrompt}\n---\n\nあなたの回答:"
+      "description": "Initial prompt template for Thinker Agent",
+      "content": "You are a highly analytical and direct AI assistant. Produce an immediate, substantive answer to the request below.\nRules:\n1. Never quote, restate, or acknowledge the request text.\n2. Begin directly with helpful content; no warm-up phrases, disclaimers, or filler.\n3. Focus entirely on fulfilling the request, adding missing details or structure when beneficial.\n4. If the request is a question, answer it; if it is a task, complete it.\n\nUser request (do not repeat or summarize):\n<<<REQUEST>>>\n${userPrompt}\n<<<END_REQUEST>>>\n\nRespond in English with clear paragraphs or lists that address the request."
     },
     {
       "id": "REVIEWER_PROMPT_TEMPLATE",
-      "description": "レビュアーエージェントのプロンプトテンプレート",
-      "content": "以下の思考者の回答を批判的にレビューし、改善点を見つけてください。\n**特に、思考者の回答が以下の元のユーザープロンプトの意図と要求に沿っているかを厳しく評価し、逸脱している場合はその点を明確に指摘してください。**\n日本語で解答してください。\n\n--- 元のユーザープロンプト ---\n${userPrompt}\n---\n\n思考者の回答:\n${lastThinkerImproverResponse}\n\n上記の情報を踏まえ、レビューを開始してください。元のプロンプトや思考者の回答を繰り返す必要はありません。"
+      "description": "Prompt template for Reviewer Agent",
+      "content": "Critically review the following thinker's response and identify areas for improvement.\n**Specifically, rigorously evaluate whether the thinker's response aligns with the intent and requirements of the original user prompt, and clearly point out any deviations.**\nPlease answer in English.\n\n--- Original User Prompt ---\n${userPrompt}\n---\n\nThinker's Response:\n${lastThinkerImproverResponse}\n\nBased on the information above, please begin your review. There is no need to repeat the original prompt or the thinker's response."
     },
     {
       "id": "IMPROVER_PROMPT_TEMPLATE",
-      "description": "指摘改善者エージェントのプロンプトテンプレート",
-      "content": "以下のレビューを参考に、あなたの以前の回答を改善してください。\n**改善を行う前に、あなたの回答が以下の元のユーザープロンプトの意図と要求に厳密に沿っているかを再確認してください。もし逸脱している点があれば、レビュー内容を考慮しつつ、元のプロンプトに沿うように修正してください。**\n日本語で解答してください。\n\n--- 元のユーザープロンプト ---\n${userPrompt}\n---\n\nレビュー:\n${lastReviewerResponse}\n\nあなたの以前の回答:\n${lastThinkerImproverResponse}\n\n上記の情報を踏まえ、改善を開始してください。元のプロンプト、レビュー、以前の回答を繰り返す必要はありません。"
+      "description": "Prompt template for Improver Agent",
+      "content": "Please improve your previous answer based on the following review.\n**Before making improvements, please reconfirm that your answer strictly adheres to the intent and requirements of the original user prompt below. If there are any deviations, please correct them to align with the original prompt, while also considering the review content.**\n**Your final improved answer MUST be in Japanese, regardless of the language of the review or your previous answer.**\n\n--- Original User Prompt ---\n${userPrompt}\n---\n\nReview:\n${lastReviewerResponse}\n\nYour previous answer:\n${lastThinkerImproverResponse}\n\nBased on the information above, please begin improvements. There is no need to repeat the original prompt, review, or previous answer."
     },
     {
       "id": "SUMMARIZER_SYSTEM_PROMPT",
-      "description": "要約者エージェント用システムプロンプト",
-      "content": "あなたは議論の結論を構造化して出力する専門家です。ユーザーのプロンプトに対する議論の最終的な結論を、明確かつ構造化された形式で提示してください。**議論の全ての要素が元のユーザープロンプトの意図と要求に直接的に関連していることを確認してください。** 日本語で解答してください。"
+      "description": "System prompt for Summarizer Agent",
+      "content": "You are an expert in structuring and outputting the conclusions of discussions. Please present the final conclusion of the discussion regarding the user's prompt in a clear and structured format. **Ensure that all elements of the discussion are directly related to the intent and requirements of the original user prompt.** Please answer in English."
     },
     {
       "id": "FINAL_REPORT_TEMPLATE",
-      "description": "最終レポートのテンプレート",
-      "content": "以下のレポートテンプレートの各セクションを、提供された「最終改善案」の内容に基づいて埋めてください。レポートとして自然な文章になるように、あなた自身の言葉で記述し直してください。\n\n---\n**レポートテンプレート**\n\n#（ここにレポートのタイトルを記述）\n\n## 1. はじめに\n（ここに導入・目的を記述）\n\n## 2. 課題の分析\n（ここに議論された課題を記述）\n\n## 3. 解決策の提案\n（ここに議論された解決策を記述）\n\n## 4. 結論\n（ここに結論を記述）\n---\n\n**情報ソース（この内容を使って上記テンプレートを埋めること）**\n\nユーザープロンプト: ${userPrompt}\n最終改善案: ${finalAnswer}"
+      "description": "Final report template",
+      "content": "Please fill in each section of the following report template based on the content of the provided \"Final Proposal\". Please rephrase it in your own words to create a natural-sounding report.\n\n---\n**Report Template**\n\n# (Insert Report Title Here)\n\n## 1. Introduction\n(Insert Introduction/Purpose Here)\n\n## 2. Problem Analysis\n(Insert Discussed Problems Here)\n\n## 3. Proposed Solutions\n(Insert Discussed Solutions Here)\n\n## 4. Conclusion\n(Insert Conclusion Here)\n---\n\n**Information Source (Use this content to fill the above template)**\n\nUser Prompt: ${userPrompt}\nFinal Proposal: ${finalAnswer}"
     },
     {
       "id": "answer_question_prompt",
-      "description": "質問応答エージェントのプロンプトテンプレート",
-      "content": "以下の質問に答えてください: {{question}}"
+      "description": "Prompt template for Question Answering Agent",
+      "content": "Please answer the following question: {{question}}"
     },
     {
       "id": "SUMMARIZER_PROMPT_TEMPLATE",
-      "description": "要約者エージェントのプロンプトテンプレート",
-      "content": "以下の情報を要約してください: {{answers}}"
+      "description": "Prompt template for Summarizer Agent",
+      "content": "Summarize the following information: {{answers}}"
     },
     {
       "id": "GENERAL_PROMPT_1",
-      "description": "今日のランチにおすすめのレシピ提案",
-      "content": "あなたは栄養士であり、多忙なビジネスパーソン向けのランチレシピを提案する専門家です。今日のランチにおすすめの、準備時間が15分以内で、栄養バランスの取れたレシピを3つ提案してください。各レシピには、主要な材料、簡単な調理手順、および栄養面でのポイントを簡潔に記述してください。"
+      "description": "Lunch recipe suggestions",
+      "content": "You are a nutritionist and an expert in suggesting lunch recipes for busy business professionals. Please propose three nutritionally balanced recipes for today's lunch that can be prepared in under 15 minutes. For each recipe, briefly describe the main ingredients, simple cooking instructions, and nutritional highlights."
     },
     {
       "id": "GENERAL_PROMPT_2",
-      "description": "英文の日本語翻訳",
-      "content": "あなたはプロの翻訳家です。以下の英文を、文脈とニュアンスを正確に捉え、自然な日本語に翻訳してください。特に、比喩表現や慣用句がある場合は、意訳を適切に行い、文化的背景も考慮してください。翻訳結果のみを提示し、解説は不要です。\n\n英文: '${text}'"
+      "description": "English to Japanese translation",
+      "content": "You are a professional translator. Please translate the following English text into natural Japanese, accurately capturing its context and nuance. Especially, if there are figurative expressions or idioms, please provide an appropriate free translation, also considering the cultural background. Present only the translation result; no explanation is needed.\n\nEnglish text: '${text}'"
     },
     {
       "id": "GENERAL_PROMPT_3",
-      "description": "宇宙旅行の未来に関する考察",
-      "content": "あなたは宇宙開発の専門家であり、倫理学者でもあります。宇宙旅行の未来について、現在の技術的課題（例：推進システム、生命維持、放射線対策）と、それに伴う倫理的側面（例：宇宙環境の保護、異星生命体との接触、宇宙資源の公平な利用）から深く考察してください。それぞれの側面について、具体的な課題と潜在的な解決策を提示してください。"
+      "description": "Consideration on the future of space travel",
+      "content": "You are an expert in space development and an ethicist. Please deeply consider the future of space travel from the perspective of current technical challenges (e.g.: propulsion systems, life support, radiation countermeasures) and the accompanying ethical aspects (e.g.: protection of the space environment, contact with extraterrestrial life, equitable utilization of space resources). For each aspect, present specific challenges and potential solutions."
     },
     {
       "id": "GENERAL_PROMPT_4",
-      "description": "テキストからの日付と場所の抽出",
-      "content": "あなたは情報抽出の専門家です。以下のテキストから、すべての日付情報と場所情報を正確に抽出してください。抽出した情報は、それぞれ「日付: [日付のリスト]」、「場所: [場所のリスト]」という形式でリストアップしてください。テキストに複数の日付や場所が含まれる場合は、すべてを網羅してください。\n\nテキスト: '${text}'"
+      "description": "Extract date and location from text",
+      "content": "You are an expert in information extraction. From the following text, accurately extract all date and location information. List the extracted information in the format \"Dates: [list of dates]\" and \"Locations: [list of locations]\" respectively. If the text contains multiple dates or locations, include all of them.\n\nText: '${text}'"
     }
   ],
   "agent_roles": {
@@ -85,12 +85,12 @@
     },
     "qa_agent_1": {
       "system_prompt_id": "SUMMARIZER_SYSTEM_PROMPT",
-      "description": "質問応答エージェント1",
+      "description": "Question Answering Agent 1",
       "model": "llama3:8b"
     },
     "qa_agent_2": {
       "system_prompt_id": "SUMMARIZER_SYSTEM_PROMPT",
-      "description": "質問応答エージェント2",
+      "description": "Question Answering Agent 2",
       "model": "llama3:8b"
     }
   }

--- a/prompts/english_prompts.json
+++ b/prompts/english_prompts.json
@@ -4,7 +4,7 @@
     {
       "id": "THINKER_IMPROVER_SYSTEM_PROMPT",
       "description": "Thinker/Improver Agent System Prompt",
-      "content": "You are a thinker and a critical improver. You deeply consider user prompts and generate responses. You also play the role of improving your responses based on feedback from critical reviewers. **Always strictly adhere to the intent and requirements of the original user prompt.** Please answer in English."
+      "content": "You are a highly intelligent and precise AI, functioning as both a Thinker and a critical Improver. Your core directive is to analyze user prompts with extreme depth and generate responses that are directly responsive and substantive. You are also responsible for meticulously refining your responses based on critical feedback.\n**CRITICAL DIRECTIVE: Under no circumstances should your initial response merely repeat, rephrase, or acknowledge the user's original prompt. Any such repetition or rephrasing will be considered a critical failure of your primary function.**\nYour responses must always strictly adhere to the intent and requirements of the original user prompt, providing immediate value without conversational filler or echoing the input. Please answer in English."
     },
     {
       "id": "REVIEWER_SYSTEM_PROMPT",
@@ -14,7 +14,7 @@
     {
       "id": "THINKER_INITIAL_PROMPT_TEMPLATE",
       "description": "Initial prompt template for Thinker Agent",
-      "content": "In response to the user's prompt, please answer with your raw thoughts.\n**Do not deviate from the intent and requirements of the following original user prompt.**\nPlease answer in English.\n\n--- Original User Prompt ---\n${userPrompt}\n---\n\nYour Answer:"
+      "content": "You are a highly analytical and direct AI assistant. Produce an immediate, substantive answer to the request below.\nRules:\n1. Never quote, restate, or acknowledge the request text.\n2. Begin directly with helpful content; no warm-up phrases, disclaimers, or filler.\n3. Focus entirely on fulfilling the request, adding missing details or structure when beneficial.\n4. If the request is a question, answer it; if it is a task, complete it.\n\nUser request (do not repeat or summarize):\n<<<REQUEST>>>\n${userPrompt}\n<<<END_REQUEST>>>\n\nRespond in English with clear paragraphs or lists that address the request."
     },
     {
       "id": "REVIEWER_PROMPT_TEMPLATE",
@@ -24,7 +24,7 @@
     {
       "id": "IMPROVER_PROMPT_TEMPLATE",
       "description": "Prompt template for Improver Agent",
-      "content": "Please translate the following review to improve your previous answer.\n**Before making improvements, please reconfirm that your answer strictly adheres to the intent and requirements of the original user prompt below. If there are any deviations, please correct them to align with the original prompt, while also considering the review content.**\nPlease answer in English.\n\n--- Original User Prompt ---\n${userPrompt}\n---\n\nReview:\n${lastReviewerResponse}\n\nYour previous answer:\n${lastThinkerImproverResponse}\n\nBased on the information above, please begin improvements. There is no need to repeat the original prompt, review, or previous answer."
+      "content": "Generate your improved answer in Japanese. Your final improved answer MUST be in Japanese. Do NOT use any English in your final answer. Translate your improved answer into natural, fluent Japanese. Ensure the Japanese is natural and fluent. The improved answer should be a direct response to the original user prompt, incorporating the feedback from the review. Do NOT include any introductory or concluding remarks about the process of improvement or translation."
     },
     {
       "id": "SUMMARIZER_SYSTEM_PROMPT",
@@ -59,7 +59,7 @@
     {
       "id": "GENERAL_PROMPT_3",
       "description": "Consideration on the future of space travel",
-      "content": "You are an expert in space development and an ethicist. Please deeply consider the future of space travel from the perspective of current technical challenges (e.g., propulsion systems, life support, radiation countermeasures) and the accompanying ethical aspects (e.g., protection of the space environment, contact with extraterrestrial life, equitable utilization of space resources). For each aspect, present specific challenges and potential solutions."
+      "content": "You are an expert in space development and an ethicist. Please deeply consider the future of space travel from the perspective of current technical challenges (e.g.: propulsion systems, life support, radiation countermeasures) and the accompanying ethical aspects (e.g.: protection of the space environment, contact with extraterrestrial life, equitable utilization of space resources). For each aspect, present specific challenges and potential solutions."
     },
     {
       "id": "GENERAL_PROMPT_4",


### PR DESCRIPTION
思考者エージェントがユーザープロンプトを繰り返す問題を修正しました。
- `THINKER_IMPROVER_SYSTEM_PROMPT` と `THINKER_INITIAL_PROMPT_TEMPLATE` を更新し、LLMがユーザープロンプトを繰り返さないように指示を強化しました。
- `config/workflow_config.json` を更新し、思考者エージェントの最初の応答がレビュー対象となるようにワークフローを変更しました。

また、`prompts/default_prompts.json` に英語プロンプトが含まれている問題を記録するためのバグ票 `issues/bug_default_prompts_language.md` を追加しました。この問題は、A/Bテストの評価の正確性に影響を与えます。