### PR TITLE
chore: fix security scan upload permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@ on:
     branches: [ main ]
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
   security-events: write
 
 jobs:


### PR DESCRIPTION
Update  workflow permissions and bump upload-sarif to v3 to resolve security scan failure.