### PR TITLE
test: add temp-dir test helper and docs for issue #110

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ npm start -- --user-prompt "技術的な質問です" --prompt-file prompts/tech
 
 - `npm test` : Jest による TypeScript テストと、A/B テスト関連の Python スクリプトを併用した統合テストを実行します。`npm run build` 済みであることに加え、テスト実行前に `source .venv/bin/activate` で Python 仮想環境を有効化する必要があります。
 - `python3 scripts/generate_reports.test.py` : Python のユニットテストを個別に実行する場合に利用します。
+- テストで一時ファイルが必要な場合は `src/testHelpers/testTempDir.ts` の `createTestTempDir` / `cleanupTestTempDir` を利用し、`afterEach` などで必ず `cleanupTestTempDir` を明示的に呼んでください（詳細: `doc/testing.md`）。
 
 ## プロジェクト構造
 

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -5,6 +5,7 @@
 テストで一時ディレクトリを使う場合は `src/testHelpers/testTempDir.ts` を利用してください。
 
 ```ts
+// 例: src/__tests__/xxx.test.ts から利用する場合
 import { cleanupTestTempDir, createTestTempDir } from '../testHelpers/testTempDir';
 
 let tempDir: string;
@@ -22,3 +23,4 @@ afterEach(() => {
 
 - `cleanupTestTempDir` は `createTestTempDir` で作成したディレクトリのみ削除します。
 - 一時ディレクトリの後片付けは自動ではありません。`afterEach` などで明示的に呼んでください。
+- import パスはテストファイルの配置に応じて調整が必要です（上記例は `src/__tests__` 配下を前提）。

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -1,0 +1,24 @@
+# Testing Utilities
+
+## Temporary Directory Helper
+
+テストで一時ディレクトリを使う場合は `src/testHelpers/testTempDir.ts` を利用してください。
+
+```ts
+import { cleanupTestTempDir, createTestTempDir } from '../testHelpers/testTempDir';
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = createTestTempDir('example-test-');
+});
+
+afterEach(() => {
+  cleanupTestTempDir(tempDir);
+});
+```
+
+## Notes
+
+- `cleanupTestTempDir` は `createTestTempDir` で作成したディレクトリのみ削除します。
+- 一時ディレクトリの後片付けは自動ではありません。`afterEach` などで明示的に呼んでください。

--- a/src/__tests__/scenarioIdentifier.test.ts
+++ b/src/__tests__/scenarioIdentifier.test.ts
@@ -1,7 +1,7 @@
-import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
 import { identifyScenario } from '../utils/scenarioIdentifier';
+import { cleanupTestTempDir, createTestTempDir } from '../testHelpers/testTempDir';
 
 const mockScenarioConfigContent = `
 {
@@ -51,7 +51,7 @@ describe('identifyScenario', () => {
       ? fs.readFileSync(productionConfigPath, 'utf8')
       : null;
     originalScenarioConfigPath = process.env.SCENARIO_CONFIG_PATH;
-    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scenario-identifier-test-'));
+    tempDir = createTestTempDir('scenario-identifier-test-');
     tempConfigPath = path.join(tempDir, 'scenario_config.json');
     fs.writeFileSync(tempConfigPath, mockScenarioConfigContent);
     process.env.SCENARIO_CONFIG_PATH = tempConfigPath;
@@ -64,9 +64,7 @@ describe('identifyScenario', () => {
       process.env.SCENARIO_CONFIG_PATH = originalScenarioConfigPath;
     }
 
-    if (tempDir && fs.existsSync(tempDir)) {
-      fs.rmSync(tempDir, { recursive: true });
-    }
+    cleanupTestTempDir(tempDir);
   });
 
   it('should identify "social_issues" scenario for a matching prompt', async () => {

--- a/src/__tests__/testTempDir.test.ts
+++ b/src/__tests__/testTempDir.test.ts
@@ -1,0 +1,34 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { cleanupTestTempDir, createTestTempDir } from '../testHelpers/testTempDir';
+
+describe('testTempDir helper', () => {
+  it('creates and cleans up a managed temp directory', () => {
+    const tempDir = createTestTempDir('helper-test-');
+    const tempFilePath = path.join(tempDir, 'temp.txt');
+    fs.writeFileSync(tempFilePath, 'ok');
+
+    expect(fs.existsSync(tempDir)).toBe(true);
+    cleanupTestTempDir(tempDir);
+    expect(fs.existsSync(tempDir)).toBe(false);
+  });
+
+  it('throws when cleaning up an unmanaged path', () => {
+    const unmanagedPath = fs.mkdtempSync(path.join(os.tmpdir(), 'unmanaged-test-'));
+
+    expect(() => cleanupTestTempDir(unmanagedPath)).toThrow(
+      `Refusing to cleanup unmanaged temp dir: ${path.resolve(unmanagedPath)}`
+    );
+    fs.rmSync(unmanagedPath, { recursive: true, force: true });
+  });
+
+  it('rejects prefixes with path segments', () => {
+    expect(() => createTestTempDir('../bad-prefix-')).toThrow(
+      'Temp dir prefix must not contain path segments: ../bad-prefix-'
+    );
+    expect(() => createTestTempDir('nested/bad-prefix-')).toThrow(
+      'Temp dir prefix must not contain path segments: nested/bad-prefix-'
+    );
+  });
+});

--- a/src/testHelpers/testTempDir.ts
+++ b/src/testHelpers/testTempDir.ts
@@ -3,10 +3,31 @@ import * as os from 'os';
 import * as path from 'path';
 
 const createdTempDirs = new Set<string>();
+const tmpRoot = path.resolve(os.tmpdir());
+
+function isWithinTmpRoot(targetPath: string): boolean {
+  const relative = path.relative(tmpRoot, targetPath);
+  return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+function validatePrefix(prefix: string): void {
+  if (!prefix) {
+    throw new Error('Temp dir prefix must not be empty');
+  }
+
+  if (prefix !== path.basename(prefix)) {
+    throw new Error(`Temp dir prefix must not contain path segments: ${prefix}`);
+  }
+}
 
 export function createTestTempDir(prefix: string): string {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  createdTempDirs.add(path.resolve(tempDir));
+  validatePrefix(prefix);
+  const tempDir = path.resolve(fs.mkdtempSync(path.join(tmpRoot, prefix)));
+  if (!isWithinTmpRoot(tempDir)) {
+    throw new Error(`Created temp dir is outside tmp root: ${tempDir}`);
+  }
+
+  createdTempDirs.add(tempDir);
   return tempDir;
 }
 
@@ -16,13 +37,15 @@ export function cleanupTestTempDir(tempDir: string): void {
   }
 
   const resolvedPath = path.resolve(tempDir);
+  if (!isWithinTmpRoot(resolvedPath)) {
+    throw new Error(`Refusing to cleanup outside tmp root: ${resolvedPath}`);
+  }
+
   if (!createdTempDirs.has(resolvedPath)) {
     throw new Error(`Refusing to cleanup unmanaged temp dir: ${resolvedPath}`);
   }
 
-  if (fs.existsSync(resolvedPath)) {
-    fs.rmSync(resolvedPath, { recursive: true, force: true });
-  }
+  fs.rmSync(resolvedPath, { recursive: true, force: true });
 
   createdTempDirs.delete(resolvedPath);
 }

--- a/src/testHelpers/testTempDir.ts
+++ b/src/testHelpers/testTempDir.ts
@@ -1,0 +1,28 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const createdTempDirs = new Set<string>();
+
+export function createTestTempDir(prefix: string): string {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  createdTempDirs.add(path.resolve(tempDir));
+  return tempDir;
+}
+
+export function cleanupTestTempDir(tempDir: string): void {
+  if (!tempDir) {
+    return;
+  }
+
+  const resolvedPath = path.resolve(tempDir);
+  if (!createdTempDirs.has(resolvedPath)) {
+    throw new Error(`Refusing to cleanup unmanaged temp dir: ${resolvedPath}`);
+  }
+
+  if (fs.existsSync(resolvedPath)) {
+    fs.rmSync(resolvedPath, { recursive: true, force: true });
+  }
+
+  createdTempDirs.delete(resolvedPath);
+}


### PR DESCRIPTION
## 概要 (Summary)
Issue #110 の要件に沿って、テスト用一時ディレクトリの共通ユーティリティ追加と関連ドキュメント更新を行いました。

## 関連Issue (Related Issues)
Closes #110

## 変更の種類 (Type of Change)
- [ ] 新機能 (New feature)
- [x] バグ修正 (Bug fix)
- [ ] リファクタリング (Refactoring)
- [x] ドキュメント更新 (Documentation)

## 詳細な変更点 (Detailed Changes)
- src/testHelpers/testTempDir.ts: テスト用一時ディレクトリ作成・削除ユーティリティを追加。作成済みパスのみ削除可能なガードを実装。
- src/__tests__/scenarioIdentifier.test.ts: 一時ディレクトリ管理を共通ユーティリティ利用に差し替え。
- doc/testing.md: ユーティリティ利用方法と注意点を追加。
- README.md: テスト実行時の一時ファイル運用（afterEach での明示 cleanup）を追記。

## 動作確認手順 (Verification Steps)
1. npm test -- scenarioIdentifier がパスすること
2. npm test がパスすること
3. llm-review -i 110 の再レビュー結果で重大指摘がないこと（PASS）

## 自己チェック (Self Check)
- [x] 既存のテストを壊していないか
- [x] 機密情報（API Key等）が含まれていないか
