### PR TITLE
feat(#85): ストーリー 7.2 エージェントモジュール責務分割と API 整合性回復

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,13 +98,22 @@ npm start -- --user-prompt "技術的な質問です" --prompt-file prompts/tech
 ## プロジェクト構造
 
 -   `src/index.ts`: CLIのエントリーポイント。ユーザーの入力を受け取り、シナリオ識別、プロンプトの動的ロード、ワークフローのオーケストレーションを調整します。
--   `src/agent.ts`: LLMとの対話ロジックと、ワークフローのオーケストレーション (`orchestrateWorkflow`関数) を定義します。
+-   `src/agent.ts`: ワークフローオーケストレーションのエントリーポイント。`orchestrateWorkflow`, `runEnsemble`, `fillTemplate` をエクスポートします。各機能は以下のモジュールに委譲されています。
+-   `src/agents/`: **エージェントモジュール**
+    -   `Agent.ts`: LLMエージェントクラス (`Agent`)、メッセージ型 (`Message`, `DiscussionTurn`) を定義します。
+    -   `index.ts`: `Agent`, `Message`, `DiscussionTurn` を re-export します。
+-   `src/guards/`: **入出力ガードモジュール**
+    -   `languageGuard.ts`: 言語ガード設定 (`LANGUAGE_GUARD_CONFIGS`)、日本語出力判定 (`requiresJapaneseOutput`)、リライトプロンプト生成 (`buildJapaneseRewritePrompt`) を提供します。
 -   `src/ollamaApi.ts`: Ollama APIとの通信を行うためのラッパー関数を提供します。
+-   `src/cooperativeAgentEval.ts`: 協調エージェント評価用CLIスクリプト。`orchestrateWorkflow` を使って指定ワークフローを実行します。
+-   `src/singleAgentEval.ts`: 単一エージェント評価用CLIスクリプト。`runEnsemble` を使います。
 -   `src/utils/`:
     -   `configLoader.ts`: 設定ファイルをロードします。
     -   `errorUtils.ts`: エラーハンドリングユーティリティ。
     -   `promptLoader.ts`: プロンプトファイル、エージェントロール、プロンプトセットをロードします。
-    -   `scenarioIdentifier.ts`: ユーザープロンプトに基づいてシナリオを識別します。
+    -   `scenarioConfig.ts`: **シナリオ設定の共通ローダー**。`loadScenarioConfig()` と `clearScenarioConfigCache()` を提供します。`SCENARIO_CONFIG_PATH` 環境変数でパスを上書き可能です。
+    -   `scenarioIdentifier.ts`: ユーザープロンプトに基づいてシナリオを識別します。内部で `scenarioConfig.ts` を使用します。
+    -   `templateUtils.ts`: テンプレート文字列のプレースホルダ置換 (`fillTemplate`) を提供します。
     -   `workflowLoader.ts`: ワークフロー定義ファイルをロードします。
 -   `config/`:
     -   `ab_test_config.json`: A/Bテストの設定ファイル。
@@ -121,6 +130,22 @@ npm start -- --user-prompt "技術的な質問です" --prompt-file prompts/tech
 -   `doc/development_plan.md`: 開発計画が記載されています。
 -   `doc/design_talk/`: LLMとの議論の要約が格納されています。
 -   `doc/design/`: 各機能の設計書が格納されます。
+
+### 主要エクスポート一覧
+
+| モジュール | エクスポート | 説明 |
+|---|---|---|
+| `src/agent.ts` | `orchestrateWorkflow` | ワークフロー定義に従いエージェントを順次実行する |
+| `src/agent.ts` | `runEnsemble` | 複数モデルに同一プロンプトを並列送信する |
+| `src/agent.ts` | `fillTemplate` | `templateUtils` からの re-export |
+| `src/agents` | `Agent` | LLMエージェントクラス |
+| `src/agents` | `Message`, `DiscussionTurn` | エージェント通信の型定義 |
+| `src/guards/languageGuard` | `requiresJapaneseOutput` | 日本語出力が必要かを判定する |
+| `src/guards/languageGuard` | `buildJapaneseRewritePrompt` | 日本語リライト指示プロンプトを生成する |
+| `src/utils/scenarioConfig` | `loadScenarioConfig` | シナリオ設定をキャッシュ付きでロードする |
+| `src/utils/scenarioConfig` | `clearScenarioConfigCache` | キャッシュをクリアする（主にテスト用途） |
+| `src/utils/templateUtils` | `fillTemplate` | `${key}` 形式のプレースホルダを置換する |
+
 
 ## ライセンス
 

--- a/checkpoint/2026-03-16__multi-llm-agent-cli-poc__ISSUE-85.md
+++ b/checkpoint/2026-03-16__multi-llm-agent-cli-poc__ISSUE-85.md
@@ -1,0 +1,5 @@
+# Timeline
+
+- 19:25 [coding] act: ストーリー7.2 全タスク（7.2.1/7.2.2/7.2.3）をTDDサイクルで実装完了
+  evd: Test Suites: 11 passed, 11 total / Tests: 55 passed, 55 total / npm run build 成功
+  block: なし

--- a/src/__tests__/agent.test.ts
+++ b/src/__tests__/agent.test.ts
@@ -187,4 +187,53 @@ describe('orchestrateWorkflow', () => {
 
     expect(mockChat).not.toHaveBeenCalled();
   });
+
+  it('propagates error when the LLM API fails', async () => {
+    mockChat.mockImplementationOnce((_model, _messages, _onContent, _onDone, onError) => {
+      return new Promise<void>(resolve => {
+        process.nextTick(() => {
+          onError(new Error('Ollama connection refused'));
+          resolve();
+        });
+      });
+    });
+
+    await expect(
+      orchestrateWorkflow(
+        createReviewerWorkflow(),
+        { user_input: 'テスト' },
+        createJapaneseReviewerPrompts(),
+        false
+      )
+    ).rejects.toThrow('Ollama connection refused');
+  });
+
+  it('throws when a required agent role is not configured', async () => {
+    const brokenWorkflow: WorkflowDefinition = {
+      description: 'broken workflow',
+      initial_step: 'broken_step',
+      steps: [
+        {
+          id: 'broken_step',
+          type: 'agent_interaction',
+          agent_id: 'nonexistent_agent',
+          prompt_id: 'REVIEWER_PROMPT_TEMPLATE',
+          input_variables: { userPrompt: 'user_input' },
+          output_variable: 'result',
+          next_step: 'end',
+        },
+      ],
+    };
+
+    await expect(
+      orchestrateWorkflow(
+        brokenWorkflow,
+        { user_input: 'テスト' },
+        createJapaneseReviewerPrompts(),
+        false
+      )
+    ).rejects.toThrow("Agent role 'nonexistent_agent' not found.");
+
+    expect(mockChat).not.toHaveBeenCalled();
+  });
 });

--- a/src/__tests__/agents/Agent.test.ts
+++ b/src/__tests__/agents/Agent.test.ts
@@ -1,0 +1,61 @@
+import { Agent } from '../../agents/Agent';
+
+// chatWithOllama をモック化
+jest.mock('../../ollamaApi', () => ({
+  chatWithOllama: jest.fn((_model, _messages, onContent, onDone, _onError) => {
+    process.nextTick(() => {
+      onContent('Hello');
+      onDone();
+    });
+  }),
+}));
+
+describe('Agent', () => {
+  describe('constructor', () => {
+    it('should initialize with model and systemPrompt', () => {
+      const agent = new Agent('llama3:8b', 'You are a helper.');
+      expect(agent.getModel()).toBe('llama3:8b');
+    });
+
+    it('should add system message to messages on init', () => {
+      const agent = new Agent('llama3:8b', 'You are a helper.');
+      const messages = agent.getMessages();
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toEqual({ role: 'system', content: 'You are a helper.' });
+    });
+  });
+
+  describe('getModel', () => {
+    it('should return the model name', () => {
+      const agent = new Agent('mistral:7b', 'System');
+      expect(agent.getModel()).toBe('mistral:7b');
+    });
+  });
+
+  describe('getMessages', () => {
+    it('should return a copy of messages (immutable)', () => {
+      const agent = new Agent('llama3:8b', 'System');
+      const messages = agent.getMessages();
+      messages[0].content = 'tampered';
+      // 内部状態が変わっていないこと
+      expect(agent.getMessages()[0].content).toBe('System');
+    });
+  });
+
+  describe('sendMessage', () => {
+    it('should append user and assistant messages after sendMessage', async () => {
+      const agent = new Agent('llama3:8b', 'You are a helper.');
+      const chunks: string[] = [];
+      const response = await agent.sendMessage('Hello agent', (chunk: string) => chunks.push(chunk));
+
+      expect(response).toBe('Hello');
+      expect(chunks).toEqual(['Hello']);
+
+      const messages = agent.getMessages();
+      // system + user + assistant
+      expect(messages).toHaveLength(3);
+      expect(messages[1]).toEqual({ role: 'user', content: 'Hello agent' });
+      expect(messages[2]).toEqual({ role: 'assistant', content: 'Hello' });
+    });
+  });
+});

--- a/src/__tests__/guards/languageGuard.test.ts
+++ b/src/__tests__/guards/languageGuard.test.ts
@@ -1,0 +1,64 @@
+import {
+  requiresJapaneseOutput,
+  buildJapaneseRewritePrompt,
+  getLanguageGuardConfig,
+  LANGUAGE_GUARD_CONFIGS,
+} from '../../guards/languageGuard';
+
+describe('languageGuard', () => {
+  describe('LANGUAGE_GUARD_CONFIGS', () => {
+    it('should contain reviewer_agent config', () => {
+      const config = LANGUAGE_GUARD_CONFIGS.find((c: { agentId: string }) => c.agentId === 'reviewer_agent');
+      expect(config).toBeDefined();
+      expect(config?.threshold).toBeGreaterThan(0);
+      expect(config?.maxAttempts).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getLanguageGuardConfig', () => {
+    it('should return config for known agentId', () => {
+      const config = getLanguageGuardConfig('reviewer_agent');
+      expect(config).toBeDefined();
+      expect(config?.agentId).toBe('reviewer_agent');
+    });
+
+    it('should return undefined for unknown agentId', () => {
+      const config = getLanguageGuardConfig('unknown_agent');
+      expect(config).toBeUndefined();
+    });
+  });
+
+  describe('requiresJapaneseOutput', () => {
+    it('should return true when "日本語" is in sources', () => {
+      expect(requiresJapaneseOutput('日本語で回答してください')).toBe(true);
+    });
+
+    it('should return true when "in japanese" is in sources (case-insensitive)', () => {
+      expect(requiresJapaneseOutput('Please answer In Japanese')).toBe(true);
+    });
+
+    it('should return false when sources have no Japanese requirement', () => {
+      expect(requiresJapaneseOutput('Please answer in English')).toBe(false);
+    });
+
+    it('should return false when all sources are undefined or empty', () => {
+      expect(requiresJapaneseOutput(undefined, undefined)).toBe(false);
+    });
+
+    it('should handle multiple sources and return true if any contains "日本語"', () => {
+      expect(requiresJapaneseOutput('Answer this:', '日本語で')).toBe(true);
+    });
+  });
+
+  describe('buildJapaneseRewritePrompt', () => {
+    it('should include retry count in the prompt', () => {
+      const prompt = buildJapaneseRewritePrompt(1);
+      expect(prompt).toContain('1');
+    });
+
+    it('should include Japanese instruction', () => {
+      const prompt = buildJapaneseRewritePrompt(2);
+      expect(prompt).toContain('日本語');
+    });
+  });
+});

--- a/src/__tests__/scenarioConfig.test.ts
+++ b/src/__tests__/scenarioConfig.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { loadScenarioConfig, clearScenarioConfigCache } from '../utils/scenarioConfig';
+import { cleanupTestTempDir, createTestTempDir } from '../testHelpers/testTempDir';
 
 const mockConfigContent = JSON.stringify({
   scenarios: [
@@ -22,34 +23,27 @@ const mockConfigContent = JSON.stringify({
 });
 
 describe('scenarioConfig', () => {
-  const tempConfigPath = path.resolve(__dirname, '../../config/scenario_config.json');
-  let originalConfig: string | null = null;
-
-  beforeAll(() => {
-    // 既存の設定ファイルがあればバックアップ
-    if (fs.existsSync(tempConfigPath)) {
-      originalConfig = fs.readFileSync(tempConfigPath, 'utf8');
-    }
-    fs.mkdirSync(path.dirname(tempConfigPath), { recursive: true });
-    fs.writeFileSync(tempConfigPath, mockConfigContent);
-  });
-
-  afterAll(() => {
-    // 元に戻す
-    if (originalConfig !== null) {
-      fs.writeFileSync(tempConfigPath, originalConfig);
-    } else if (fs.existsSync(tempConfigPath)) {
-      fs.unlinkSync(tempConfigPath);
-    }
-  });
+  let tempDir: string;
+  let tempConfigPath: string;
+  let originalScenarioConfigPath: string | undefined;
 
   beforeEach(() => {
+    originalScenarioConfigPath = process.env.SCENARIO_CONFIG_PATH;
+    tempDir = createTestTempDir('scenario-config-test-');
+    tempConfigPath = path.join(tempDir, 'scenario_config.json');
+    fs.writeFileSync(tempConfigPath, mockConfigContent);
+    process.env.SCENARIO_CONFIG_PATH = tempConfigPath;
     clearScenarioConfigCache();
-    delete process.env.SCENARIO_CONFIG_PATH;
   });
 
   afterEach(() => {
-    delete process.env.SCENARIO_CONFIG_PATH;
+    if (originalScenarioConfigPath === undefined) {
+      delete process.env.SCENARIO_CONFIG_PATH;
+    } else {
+      process.env.SCENARIO_CONFIG_PATH = originalScenarioConfigPath;
+    }
+    cleanupTestTempDir(tempDir);
+    clearScenarioConfigCache();
   });
 
   it('should load scenario config from default path', async () => {
@@ -74,25 +68,31 @@ describe('scenarioConfig', () => {
     expect(second.default_scenario_id).toBe('default_scenario');
   });
 
-  it('should use SCENARIO_CONFIG_PATH env var when set', async () => {
-    // 別パスに別のモック設定ファイルを用意
-    const altPath = path.resolve(__dirname, 'test_prompts/alt_scenario_config.json');
-    fs.mkdirSync(path.dirname(altPath), { recursive: true });
+  it('should reload when SCENARIO_CONFIG_PATH changes to a different file', async () => {
+    const altDir = createTestTempDir('scenario-config-alt-');
+    const altPath = path.join(altDir, 'alt_scenario_config.json');
     const altContent = JSON.stringify({
       scenarios: [{ id: 'alt_scenario', name: 'Alt', description: 'Alt', keywords: [] }],
       default_scenario_id: 'alt_scenario',
     });
     fs.writeFileSync(altPath, altContent);
 
-    process.env.SCENARIO_CONFIG_PATH = altPath;
-    const config = await loadScenarioConfig();
-    expect(config.default_scenario_id).toBe('alt_scenario');
+    try {
+      const first = await loadScenarioConfig();
+      expect(first.default_scenario_id).toBe('default_scenario');
 
-    fs.unlinkSync(altPath);
+      process.env.SCENARIO_CONFIG_PATH = altPath;
+      const second = await loadScenarioConfig();
+      expect(second.default_scenario_id).toBe('alt_scenario');
+    } finally {
+      cleanupTestTempDir(altDir);
+    }
   });
 
-  it('should throw an error if config file does not exist', async () => {
+  it('should throw an error with file path when config file does not exist', async () => {
     process.env.SCENARIO_CONFIG_PATH = '/nonexistent/path/scenario_config.json';
-    await expect(loadScenarioConfig()).rejects.toThrow();
+    await expect(loadScenarioConfig()).rejects.toThrow(
+      "Failed to load scenario config from '/nonexistent/path/scenario_config.json'"
+    );
   });
 });

--- a/src/__tests__/scenarioConfig.test.ts
+++ b/src/__tests__/scenarioConfig.test.ts
@@ -1,0 +1,98 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { loadScenarioConfig, clearScenarioConfigCache } from '../utils/scenarioConfig';
+
+const mockConfigContent = JSON.stringify({
+  scenarios: [
+    {
+      id: 'test_scenario',
+      name: 'テスト',
+      description: 'テスト用シナリオ',
+      keywords: ['テスト'],
+      default_workflow_id: 'test_workflow',
+    },
+    {
+      id: 'default_scenario',
+      name: 'デフォルト',
+      description: 'デフォルトシナリオ',
+      keywords: [],
+    },
+  ],
+  default_scenario_id: 'default_scenario',
+});
+
+describe('scenarioConfig', () => {
+  const tempConfigPath = path.resolve(__dirname, '../../config/scenario_config.json');
+  let originalConfig: string | null = null;
+
+  beforeAll(() => {
+    // 既存の設定ファイルがあればバックアップ
+    if (fs.existsSync(tempConfigPath)) {
+      originalConfig = fs.readFileSync(tempConfigPath, 'utf8');
+    }
+    fs.mkdirSync(path.dirname(tempConfigPath), { recursive: true });
+    fs.writeFileSync(tempConfigPath, mockConfigContent);
+  });
+
+  afterAll(() => {
+    // 元に戻す
+    if (originalConfig !== null) {
+      fs.writeFileSync(tempConfigPath, originalConfig);
+    } else if (fs.existsSync(tempConfigPath)) {
+      fs.unlinkSync(tempConfigPath);
+    }
+  });
+
+  beforeEach(() => {
+    clearScenarioConfigCache();
+    delete process.env.SCENARIO_CONFIG_PATH;
+  });
+
+  afterEach(() => {
+    delete process.env.SCENARIO_CONFIG_PATH;
+  });
+
+  it('should load scenario config from default path', async () => {
+    const config = await loadScenarioConfig();
+    expect(config.default_scenario_id).toBe('default_scenario');
+    expect(config.scenarios).toHaveLength(2);
+    expect(config.scenarios[0].id).toBe('test_scenario');
+  });
+
+  it('should return the same cached object on second call', async () => {
+    const first = await loadScenarioConfig();
+    const second = await loadScenarioConfig();
+    expect(first).toBe(second); // 同一参照であること
+  });
+
+  it('should clear cache and reload after clearScenarioConfigCache()', async () => {
+    const first = await loadScenarioConfig();
+    clearScenarioConfigCache();
+    const second = await loadScenarioConfig();
+    // キャッシュクリア後は新たに読み込むため別オブジェクト
+    expect(first).not.toBe(second);
+    expect(second.default_scenario_id).toBe('default_scenario');
+  });
+
+  it('should use SCENARIO_CONFIG_PATH env var when set', async () => {
+    // 別パスに別のモック設定ファイルを用意
+    const altPath = path.resolve(__dirname, 'test_prompts/alt_scenario_config.json');
+    fs.mkdirSync(path.dirname(altPath), { recursive: true });
+    const altContent = JSON.stringify({
+      scenarios: [{ id: 'alt_scenario', name: 'Alt', description: 'Alt', keywords: [] }],
+      default_scenario_id: 'alt_scenario',
+    });
+    fs.writeFileSync(altPath, altContent);
+
+    process.env.SCENARIO_CONFIG_PATH = altPath;
+    const config = await loadScenarioConfig();
+    expect(config.default_scenario_id).toBe('alt_scenario');
+
+    fs.unlinkSync(altPath);
+  });
+
+  it('should throw an error if config file does not exist', async () => {
+    process.env.SCENARIO_CONFIG_PATH = '/nonexistent/path/scenario_config.json';
+    await expect(loadScenarioConfig()).rejects.toThrow();
+  });
+});

--- a/src/__tests__/scenarioIdentifier.test.ts
+++ b/src/__tests__/scenarioIdentifier.test.ts
@@ -1,3 +1,4 @@
+import { clearScenarioConfigCache } from '../utils/scenarioConfig';
 import * as fs from 'fs';
 import * as path from 'path';
 import { identifyScenario } from '../utils/scenarioIdentifier';
@@ -55,6 +56,7 @@ describe('identifyScenario', () => {
     tempConfigPath = path.join(tempDir, 'scenario_config.json');
     fs.writeFileSync(tempConfigPath, mockScenarioConfigContent);
     process.env.SCENARIO_CONFIG_PATH = tempConfigPath;
+    clearScenarioConfigCache();
   });
 
   afterEach(() => {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,120 +1,18 @@
 import { chatWithOllama } from './ollamaApi';
 import { PromptFileContent, getPromptById, getAgentRoleById } from './utils/promptLoader';
 import { calculateJapaneseCharacterRatio, isLikelyJapanese } from './utils/languageUtils';
-
-interface Message {
-  role: string;
-  content: string;
-}
-
-interface DiscussionTurn {
-  turn: string;
-  agent_role: string;
-  prompt_sent: string;
-  response_received: string;
-}
-
-interface LanguageGuardConfig {
-  agentId: string;
-  threshold: number;
-  maxAttempts: number;
-}
-
-const DEFAULT_JAPANESE_THRESHOLD = 0.3;
-const DEFAULT_RETRY_ATTEMPTS = 2;
-
-const LANGUAGE_GUARD_CONFIGS: LanguageGuardConfig[] = [
-  { agentId: 'reviewer_agent', threshold: 0.3, maxAttempts: 2 },
-  { agentId: 'thinker_improver_agent', threshold: 0.3, maxAttempts: 1 },
-  { agentId: 'summarizer_agent', threshold: 0.3, maxAttempts: 1 },
-];
-
-function getLanguageGuardConfig(agentId: string): LanguageGuardConfig | undefined {
-  return LANGUAGE_GUARD_CONFIGS.find(config => config.agentId === agentId);
-}
-
-function requiresJapaneseOutput(...sources: Array<string | undefined>): boolean {
-  const combined = sources.filter(Boolean).join(' ').toLowerCase();
-  if (!combined) {
-    return false;
-  }
-
-  if (combined.includes('日本語')) {
-    return true;
-  }
-
-  return combined.includes('in japanese');
-}
-
-function buildJapaneseRewritePrompt(attempt: number): string {
-  return [
-    '直前の応答には日本語以外の要素が含まれています。',
-    '直前に返した内容と同じ意味を保ちながら、英語の単語や文章を含めずに完全に日本語で書き直してください。',
-    '必要に応じて語彙や表現を調整しても構いませんが、回答全体を日本語で提示してください。',
-    `再試行回数: ${attempt}`,
-  ].join('\n');
-}
-
-class Agent {
-  private model: string;
-  private systemPrompt: string;
-  private messages: Message[];
-  private temperature?: number;
-  private jsonOutput: boolean; // Add jsonOutput property
-
-  constructor(
-    model: string,
-    systemPrompt: string,
-    temperature?: number,
-    jsonOutput: boolean = false
-  ) {
-    // Add jsonOutput to constructor
-    this.model = model;
-    this.systemPrompt = systemPrompt;
-    this.messages = [{ role: 'system', content: systemPrompt }];
-    this.temperature = temperature;
-    this.jsonOutput = jsonOutput; // Store jsonOutput
-  }
-
-  public async sendMessage(
-    userMessage: string,
-    onContent: (content: string) => void
-  ): Promise<string> {
-    this.messages.push({ role: 'user', content: userMessage });
-    let agentResponse = '';
-
-    await new Promise<void>((resolve, reject) => {
-      chatWithOllama(
-        this.model,
-        this.messages,
-        contentChunk => {
-          agentResponse += contentChunk;
-          onContent(contentChunk);
-        },
-        () => {
-          resolve();
-        },
-        error => {
-          reject(error);
-        },
-        this.temperature,
-        this.jsonOutput // Pass jsonOutput to chatWithOllama
-      );
-    });
-
-    this.messages.push({ role: 'assistant', content: agentResponse });
-    return agentResponse;
-  }
-
-  public getModel(): string {
-    return this.model;
-  }
-
-  public getMessages(): Message[] {
-    // Return a deep copy to prevent external mutation
-    return this.messages.map(msg => ({ ...msg }));
-  }
-}
+import { fillTemplate } from './utils/templateUtils';
+export { fillTemplate }; // 後方互換のため re-export する
+import { Agent, DiscussionTurn } from './agents';
+import {
+  LanguageGuardConfig,
+  LANGUAGE_GUARD_CONFIGS,
+  DEFAULT_JAPANESE_THRESHOLD,
+  DEFAULT_RETRY_ATTEMPTS,
+  getLanguageGuardConfig,
+  requiresJapaneseOutput,
+  buildJapaneseRewritePrompt,
+} from './guards/languageGuard';
 
 import {
   WorkflowDefinition,
@@ -441,15 +339,4 @@ export async function runEnsemble(prompt: string, models: string[]): Promise<str
     ensembleResponses.push(fullResponse);
   }
   return ensembleResponses;
-}
-
-export function fillTemplate(template: string, variables: { [key: string]: string }): string {
-  let result = template;
-  for (const key in variables) {
-    if (Object.prototype.hasOwnProperty.call(variables, key)) {
-      const placeholder = `\\$\\{${key}\\}`;
-      result = result.replace(new RegExp(placeholder, 'g'), variables[key]);
-    }
-  }
-  return result;
 }

--- a/src/agents/Agent.ts
+++ b/src/agents/Agent.ts
@@ -1,0 +1,72 @@
+import { chatWithOllama } from '../ollamaApi';
+
+export interface Message {
+  role: string;
+  content: string;
+}
+
+export interface DiscussionTurn {
+  turn: string;
+  agent_role: string;
+  prompt_sent: string;
+  response_received: string;
+}
+
+export class Agent {
+  private model: string;
+  private systemPrompt: string;
+  private messages: Message[];
+  private temperature?: number;
+  private jsonOutput: boolean;
+
+  constructor(
+    model: string,
+    systemPrompt: string,
+    temperature?: number,
+    jsonOutput: boolean = false
+  ) {
+    this.model = model;
+    this.systemPrompt = systemPrompt;
+    this.messages = [{ role: 'system', content: systemPrompt }];
+    this.temperature = temperature;
+    this.jsonOutput = jsonOutput;
+  }
+
+  public async sendMessage(
+    userMessage: string,
+    onContent: (content: string) => void
+  ): Promise<string> {
+    this.messages.push({ role: 'user', content: userMessage });
+    let agentResponse = '';
+
+    await new Promise<void>((resolve, reject) => {
+      chatWithOllama(
+        this.model,
+        this.messages,
+        contentChunk => {
+          agentResponse += contentChunk;
+          onContent(contentChunk);
+        },
+        () => {
+          resolve();
+        },
+        error => {
+          reject(error);
+        },
+        this.temperature,
+        this.jsonOutput
+      );
+    });
+
+    this.messages.push({ role: 'assistant', content: agentResponse });
+    return agentResponse;
+  }
+
+  public getModel(): string {
+    return this.model;
+  }
+
+  public getMessages(): Message[] {
+    return this.messages.map(msg => ({ ...msg }));
+  }
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,0 +1,2 @@
+export { Agent } from './Agent';
+export type { Message, DiscussionTurn } from './Agent';

--- a/src/cooperativeAgentEval.ts
+++ b/src/cooperativeAgentEval.ts
@@ -1,48 +1,46 @@
-import { conductConsultation } from './agent';
-import { loadPromptFile, PromptFileContent } from './utils/promptLoader';
+import { orchestrateWorkflow } from './agent';
+import { loadPromptSetByScenarioId } from './utils/promptLoader';
+import { loadWorkflowFile } from './utils/workflowLoader';
+import { identifyScenario } from './utils/scenarioIdentifier';
 import * as path from 'path';
 
 async function main() {
   const args = process.argv.slice(2);
   const userPrompt = args[0];
-  const model1 = args[1] || 'llama3:8b'; // Default to llama3:8b if not provided
-  const model2 = args[2] || 'llama3:8b'; // Default to llama3:8b if not provided
-  const cycles = parseInt(args[3] || '2', 10); // Default to 2 cycles if not provided
+  const workflowId = args[1] || 'code_review_and_refactor';
 
   if (!userPrompt) {
     console.error(
-      'Usage: ts-node src/cooperativeAgentEval.ts <your_prompt> [model1] [model2] [cycles]'
+      'Usage: ts-node src/cooperativeAgentEval.ts <your_prompt> [workflowId]'
     );
     process.exit(1);
   }
 
   console.log(`Starting cooperative agent evaluation for prompt: "${userPrompt}"`);
-  console.log(`Using Agent 1: ${model1}, Agent 2: ${model2}, Cycles: ${cycles}`);
-
-  let prompts: PromptFileContent;
-  const defaultPromptFilePath = path.resolve(process.cwd(), 'prompts', 'default_prompts.json');
-  try {
-    prompts = await loadPromptFile(defaultPromptFilePath);
-    console.log(`Loaded default prompts from: ${defaultPromptFilePath}`);
-  } catch (error) {
-    console.error(`Error loading default prompt file: ${error}`);
-    process.exit(1);
-  }
+  console.log(`Using workflow: ${workflowId}`);
 
   try {
-    const { finalSummary, discussionLog } = await conductConsultation(
-      userPrompt,
-      model1,
-      model2,
+    const scenario = await identifyScenario(userPrompt);
+    const prompts = await loadPromptSetByScenarioId(scenario.id);
+
+    const workflowFilePath = path.resolve(process.cwd(), 'config', 'workflow_config.json');
+    const workflowConfig = await loadWorkflowFile(workflowFilePath);
+    if (!Object.prototype.hasOwnProperty.call(workflowConfig.workflows, workflowId)) {
+      throw new Error(`Workflow '${workflowId}' not found in workflow_config.json.`);
+    }
+    const workflow = workflowConfig.workflows[workflowId];
+
+    const { finalOutput, discussionLog } = await orchestrateWorkflow(
+      workflow,
+      { user_input: userPrompt },
       prompts,
-      cycles
+      false
     );
-    console.log('\n--- Cooperative Agent Result ---');
 
-    console.log(finalSummary);
-    console.log('\n--- Cooperative Agent Discussion Log Start ---');
+    console.log('\n--- Cooperative Agent Result ---');
+    console.log(JSON.stringify(finalOutput, null, 2));
+    console.log('\n--- Discussion Log ---');
     console.log(JSON.stringify(discussionLog, null, 2));
-    console.log('--- Cooperative Agent Discussion Log End ---');
   } catch (error) {
     console.error('An error occurred during cooperative agent evaluation:', error);
   }

--- a/src/guards/languageGuard.ts
+++ b/src/guards/languageGuard.ts
@@ -8,9 +8,9 @@ export const DEFAULT_JAPANESE_THRESHOLD = 0.3;
 export const DEFAULT_RETRY_ATTEMPTS = 2;
 
 export const LANGUAGE_GUARD_CONFIGS: LanguageGuardConfig[] = [
-  { agentId: 'reviewer_agent', threshold: 0.3, maxAttempts: 2 },
-  { agentId: 'thinker_improver_agent', threshold: 0.3, maxAttempts: 1 },
-  { agentId: 'summarizer_agent', threshold: 0.3, maxAttempts: 1 },
+  { agentId: 'reviewer_agent', threshold: DEFAULT_JAPANESE_THRESHOLD, maxAttempts: DEFAULT_RETRY_ATTEMPTS },
+  { agentId: 'thinker_improver_agent', threshold: DEFAULT_JAPANESE_THRESHOLD, maxAttempts: 1 },
+  { agentId: 'summarizer_agent', threshold: DEFAULT_JAPANESE_THRESHOLD, maxAttempts: 1 },
 ];
 
 export function getLanguageGuardConfig(agentId: string): LanguageGuardConfig | undefined {

--- a/src/guards/languageGuard.ts
+++ b/src/guards/languageGuard.ts
@@ -1,0 +1,38 @@
+export interface LanguageGuardConfig {
+  agentId: string;
+  threshold: number;
+  maxAttempts: number;
+}
+
+export const DEFAULT_JAPANESE_THRESHOLD = 0.3;
+export const DEFAULT_RETRY_ATTEMPTS = 2;
+
+export const LANGUAGE_GUARD_CONFIGS: LanguageGuardConfig[] = [
+  { agentId: 'reviewer_agent', threshold: 0.3, maxAttempts: 2 },
+  { agentId: 'thinker_improver_agent', threshold: 0.3, maxAttempts: 1 },
+  { agentId: 'summarizer_agent', threshold: 0.3, maxAttempts: 1 },
+];
+
+export function getLanguageGuardConfig(agentId: string): LanguageGuardConfig | undefined {
+  return LANGUAGE_GUARD_CONFIGS.find(config => config.agentId === agentId);
+}
+
+export function requiresJapaneseOutput(...sources: Array<string | undefined>): boolean {
+  const combined = sources.filter(Boolean).join(' ').toLowerCase();
+  if (!combined) {
+    return false;
+  }
+  if (combined.includes('日本語')) {
+    return true;
+  }
+  return combined.includes('in japanese');
+}
+
+export function buildJapaneseRewritePrompt(attempt: number): string {
+  return [
+    '直前の応答には日本語以外の要素が含まれています。',
+    '直前に返した内容と同じ意味を保ちながら、英語の単語や文章を含めずに完全に日本語で書き直してください。',
+    '必要に応じて語彙や表現を調整しても構いませんが、回答全体を日本語で提示してください。',
+    `再試行回数: ${attempt}`,
+  ].join('\n');
+}

--- a/src/utils/promptLoader.ts
+++ b/src/utils/promptLoader.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { loadScenarioConfig } from './scenarioConfig';
 
 // プロンプト定義の型
 export interface PromptDefinition {
@@ -21,40 +22,6 @@ export interface PromptFileContent {
   format_version: string;
   prompts: PromptDefinition[];
   agent_roles?: { [key: string]: AgentRoleDefinition }; // agent_rolesを追加
-}
-
-// シナリオ設定の型
-interface ScenarioConfig {
-  scenarios: {
-    id: string;
-    name: string;
-    description: string;
-    keywords: string[];
-    default_workflow_id: string;
-    prompt_file_path: string; // 追加
-  }[];
-  default_scenario_id: string;
-}
-
-let cachedScenarioConfig: ScenarioConfig | null = null;
-
-async function loadScenarioConfig(): Promise<ScenarioConfig> {
-  if (cachedScenarioConfig) {
-    return cachedScenarioConfig;
-  }
-  const configPath = path.resolve(process.cwd(), 'config/scenario_config.json');
-  if (!fs.existsSync(configPath)) {
-    throw new Error('scenario_config.json not found');
-  }
-  const data = await fs.promises.readFile(configPath, 'utf8');
-  let config: ScenarioConfig;
-  try {
-    config = JSON.parse(data);
-  } catch (jsonError) {
-    throw new Error('Invalid scenario_config.json format');
-  }
-  cachedScenarioConfig = config;
-  return config;
 }
 
 /**

--- a/src/utils/scenarioConfig.ts
+++ b/src/utils/scenarioConfig.ts
@@ -1,0 +1,40 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface Scenario {
+  id: string;
+  name: string;
+  description: string;
+  keywords: string[];
+  default_workflow_id?: string;
+  prompt_file_path?: string;
+}
+
+export interface ScenarioConfig {
+  scenarios: Scenario[];
+  default_scenario_id: string;
+}
+
+let scenarioConfigCache: ScenarioConfig | null = null;
+
+function resolveConfigPath(): string {
+  if (process.env.SCENARIO_CONFIG_PATH) {
+    return process.env.SCENARIO_CONFIG_PATH;
+  }
+  return path.resolve(process.cwd(), 'config/scenario_config.json');
+}
+
+export async function loadScenarioConfig(): Promise<ScenarioConfig> {
+  if (scenarioConfigCache) {
+    return scenarioConfigCache;
+  }
+  const configPath = resolveConfigPath();
+  const data = await fs.promises.readFile(configPath, 'utf8');
+  const parsed: ScenarioConfig = JSON.parse(data);
+  scenarioConfigCache = parsed;
+  return parsed;
+}
+
+export function clearScenarioConfigCache(): void {
+  scenarioConfigCache = null;
+}

--- a/src/utils/scenarioConfig.ts
+++ b/src/utils/scenarioConfig.ts
@@ -15,6 +15,7 @@ export interface ScenarioConfig {
   default_scenario_id: string;
 }
 
+let cachedConfigPath: string | null = null;
 let scenarioConfigCache: ScenarioConfig | null = null;
 
 function resolveConfigPath(): string {
@@ -25,16 +26,24 @@ function resolveConfigPath(): string {
 }
 
 export async function loadScenarioConfig(): Promise<ScenarioConfig> {
-  if (scenarioConfigCache) {
+  const configPath = resolveConfigPath();
+  if (scenarioConfigCache && cachedConfigPath === configPath) {
     return scenarioConfigCache;
   }
-  const configPath = resolveConfigPath();
-  const data = await fs.promises.readFile(configPath, 'utf8');
-  const parsed: ScenarioConfig = JSON.parse(data);
-  scenarioConfigCache = parsed;
-  return parsed;
+  try {
+    const data = await fs.promises.readFile(configPath, 'utf8');
+    const parsed: ScenarioConfig = JSON.parse(data);
+    scenarioConfigCache = parsed;
+    cachedConfigPath = configPath;
+    return parsed;
+  } catch (err) {
+    throw new Error(
+      `Failed to load scenario config from '${configPath}': ${(err as Error).message}`
+    );
+  }
 }
 
 export function clearScenarioConfigCache(): void {
   scenarioConfigCache = null;
+  cachedConfigPath = null;
 }

--- a/src/utils/scenarioIdentifier.ts
+++ b/src/utils/scenarioIdentifier.ts
@@ -1,47 +1,6 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import { loadScenarioConfig, Scenario } from './scenarioConfig';
 
-export interface Scenario {
-  id: string;
-  name: string;
-  description: string;
-  keywords: string[];
-  default_workflow_id?: string;
-}
-
-interface ScenarioConfig {
-  scenarios: Scenario[];
-  default_scenario_id: string;
-}
-
-const defaultScenarioConfigPath = path.resolve(
-  process.cwd(),
-  'config/scenario_config.json'
-);
-
-let scenarioConfigCache: ScenarioConfig | null = null;
-
-function getScenarioConfigPath(): string {
-  return process.env.SCENARIO_CONFIG_PATH ?? defaultScenarioConfigPath;
-}
-
-async function loadScenarioConfig(): Promise<ScenarioConfig> {
-  const configPath = getScenarioConfigPath();
-  const shouldUseCache = path.resolve(configPath) === path.resolve(defaultScenarioConfigPath);
-
-  if (shouldUseCache && scenarioConfigCache) {
-    return scenarioConfigCache;
-  }
-
-  const data = await fs.promises.readFile(configPath, 'utf8');
-  const parsedConfig: ScenarioConfig = JSON.parse(data);
-
-  if (shouldUseCache) {
-    scenarioConfigCache = parsedConfig;
-  }
-
-  return parsedConfig;
-}
+export type { Scenario };
 
 export async function identifyScenario(userPrompt: string): Promise<Scenario> {
   const config = await loadScenarioConfig();

--- a/src/utils/templateUtils.ts
+++ b/src/utils/templateUtils.ts
@@ -1,0 +1,10 @@
+export function fillTemplate(template: string, variables: { [key: string]: string }): string {
+  let result = template;
+  for (const key in variables) {
+    if (Object.prototype.hasOwnProperty.call(variables, key)) {
+      const placeholder = `\\$\\{${key}\\}`;
+      result = result.replace(new RegExp(placeholder, 'g'), variables[key]);
+    }
+  }
+  return result;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     "src/**/*.ts"
   ],
   "exclude": [
-    "node_modules",
-    "src/cooperativeAgentEval.ts"
+    "node_modules"
   ]
 }


### PR DESCRIPTION
## 概要 (Summary)

`src/agent.ts` に集中していた Agent クラス・言語ガード・テンプレート処理・シナリオ設定ローダーを専用モジュールへ分割し、保守性を向上させました。また `cooperativeAgentEval.ts` が依存していた存在しない `conductConsultation` API を廃止し、実在する `orchestrateWorkflow` に置き換えてビルドエラーを解消しました。

## 関連Issue (Related Issues)

Closes #85

## 変更の種類 (Type of Change)

- [ ] 新機能 (New feature)
- [ ] バグ修正 (Bug fix)
- [x] リファクタリング (Refactoring)
- [x] ドキュメント更新 (Documentation)

## 詳細な変更点 (Detailed Changes)

### タスク 7.2.3: シナリオ設定ローダーの共通化
- `src/utils/scenarioConfig.ts`（新規）: `loadScenarioConfig()`・`clearScenarioConfigCache()`・`Scenario`・`ScenarioConfig` 型を提供する唯一の実装
- `src/utils/promptLoader.ts`: 内部に重複実装していた `loadScenarioConfig` を削除し、上記を import
- `src/utils/scenarioIdentifier.ts`: 同様に重複実装を削除、`scenarioConfig.ts` から import して re-export

### タスク 7.2.2: agent.ts の責務分割
- `src/agents/Agent.ts`（新規）: `Agent` クラス・`Message`・`DiscussionTurn` 型
- `src/guards/languageGuard.ts`（新規）: 日本語出力ガードロジック一式 (`LANGUAGE_GUARD_CONFIGS`, `requiresJapaneseOutput`, `buildJapaneseRewritePrompt` 等)
- `src/utils/templateUtils.ts`（新規）: `fillTemplate` の実装本体
- `src/agent.ts`: 上記モジュールへ委譲、後方互換のため `fillTemplate`・`runEnsemble` を re-export で維持

### タスク 7.2.1: cooperativeAgentEval の API 整合性修正
- `src/cooperativeAgentEval.ts`: `conductConsultation`（未実装）→ `orchestrateWorkflow` に全面書き直し。CLI 引数を `<userPrompt> [workflowId]` に変更
- `tsconfig.json`: `exclude` から `cooperativeAgentEval.ts` を削除（ビルド対象に復帰）

### セキュリティ・品質改善（レビュー指摘対応）
- `src/cooperativeAgentEval.ts`: `workflowConfig.workflows[workflowId]` アクセス前に `Object.prototype.hasOwnProperty.call()` ガードを追加（プロトタイプ汚染対策）
- `src/__tests__/agent.test.ts`: `orchestrateWorkflow` の異常系テスト 2 件を追加（LLM API エラー・入力変数不足）
- `src/agent.ts`: `fillTemplate` の重複 import/export を解消

### ドキュメント
- `README.md`: プロジェクト構造セクションを新モジュール構成に更新、主要エクスポート一覧テーブルを追加

## 動作確認手順 (Verification Steps)

```bash
npm run build   # ビルド成功（エラー 0 件）
npm test        # 11 スイート、57 テスト、全件 Green
```

## 自己チェック (Self Check)

- [x] 既存のテストを壊していないか（57 tests passed）
- [x] 機密情報（API Key等）が含まれていないか
- [x] 後方互換性を維持しているか（agent.ts からの re-export）
- [x] セキュリティガード（hasOwnProperty）を追加済み