### PR TITLE
fix(#114): ab_test_runner の JSON ロギング改善とテスト追加

### DIFF
--- a/scripts/ab_test_runner.py
+++ b/scripts/ab_test_runner.py
@@ -151,42 +151,37 @@ def main():
                     if not current_config_file or not current_workflow_id:
                         logging(f"Error: Static group '{group_id}' is missing 'prompt_file_path' or 'workflow_id'. Skipping.", args.json)
                         continue
-
-                    try:
-                        summary, log = run_llm_consultation(
-                            user_prompt, # ここで test_prompts から取得した user_prompt を使用
-                            evaluation_models[0],
-                            evaluation_models[1],
-                            workflow_id=current_workflow_id,
-                            prompt_file=current_config_file,
-                            prompt_language=group.get("prompt_language"),
-                            is_json=args.json
-                        )
-                    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
-                        emit_error(f"LLM consultation failed: {e}", args.json)
-                        sys.exit(1)
+                    kwargs = dict(
+                        workflow_id=current_workflow_id,
+                        prompt_file=current_config_file,
+                        prompt_language=group.get("prompt_language"),
+                        is_json=args.json,
+                    )
                 elif group_type == "dynamic":
                     scenario_based_selection = group.get("scenario_based_workflow_selection_enabled", False)
 
                     if not scenario_based_selection:
                         logging(f"Error: Dynamic group '{group_id}' has 'scenario_based_workflow_selection_enabled' as false. Skipping.", args.json)
                         continue
-
-                    try:
-                        summary, log = run_llm_consultation(
-                            user_prompt, # ここで test_prompts から取得した user_prompt を使用
-                            evaluation_models[0],
-                            evaluation_models[1],
-                            workflow_id=None, # index.js が解決
-                            prompt_language=group.get("prompt_language"),
-                            is_json=args.json
-                        )
-                    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
-                        emit_error(f"LLM consultation failed: {e}", args.json)
-                        sys.exit(1)
+                    kwargs = dict(
+                        workflow_id=None, # index.js が解決
+                        prompt_language=group.get("prompt_language"),
+                        is_json=args.json,
+                    )
                 else:
                     logging(f"Error: Unknown group type '{group_type}' for group '{group_id}'. Skipping.", args.json)
                     continue
+
+                try:
+                    summary, log = run_llm_consultation(
+                        user_prompt,
+                        evaluation_models[0],
+                        evaluation_models[1],
+                        **kwargs,
+                    )
+                except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+                    emit_error(f"LLM consultation failed: {e}", args.json)
+                    sys.exit(1)
 
                 group_results[run_key] = {
                     "finalOutput": json.dumps(summary, indent=2, ensure_ascii=False),

--- a/scripts/ab_test_runner.py
+++ b/scripts/ab_test_runner.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 import json
 import subprocess
 from datetime import datetime
@@ -9,6 +10,22 @@ def logging(msg: str, is_json: bool):
     """json_onlyフラグがFalseのときだけメッセージをprintする"""
     if not is_json:
         print(msg)
+
+
+def emit_error(message: str, is_json: bool) -> None:
+    """Emit an error message respecting the --json flag.
+
+    JSON mode error format:
+        {"error": {"message": "<human-readable description>"}}
+
+    In JSON mode this function writes the error JSON to stdout so that
+    automated callers can parse it. In non-JSON mode it logs to stdout
+    as plain text via logging().
+    """
+    if is_json:
+        print(json.dumps({"error": {"message": message}}, ensure_ascii=False))
+    else:
+        logging(message, is_json)
 
 def run_llm_consultation(user_prompt: str, model1: str, model2: str, workflow_id: str = None, prompt_file: str = None, prompt_language: str = None, is_json: bool = False):
     """Runs the LLM consultation and returns the final summary and discussion log."""
@@ -38,14 +55,14 @@ def run_llm_consultation(user_prompt: str, model1: str, model2: str, workflow_id
         data = json.loads(result.stdout)
         return data.get('finalOutput', ''), data.get('discussionLog', [])
     except subprocess.CalledProcessError as e:
-        print(f"Error: Command '{' '.join(command)}' failed with exit code {e.returncode}", is_json)
-        print(f"Stdout:\n{e.stdout}", is_json)
-        print(f"Stderr:\n{e.stderr}", is_json)
-        return e.stdout if e.stdout else "", []  # Return error output and empty log
+        logging(f"Error: Command '{' '.join(command)}' failed with exit code {e.returncode}", is_json)
+        logging(f"Stdout:\n{e.stdout}", is_json)
+        logging(f"Stderr:\n{e.stderr}", is_json)
+        raise  # 呼び出し元で emit_error + sys.exit(1) により処理する
     except json.JSONDecodeError as e:
-        print(f"Error: Could not decode JSON from stdout: {e}", is_json)
-        print(f"Stdout:\n{result.stdout}", is_json)
-        return result.stdout, [] # Return raw stdout if JSON decoding fails
+        logging(f"Error: Could not decode JSON from stdout: {e}", is_json)
+        logging(f"Stdout:\n{result.stdout}", is_json)
+        raise  # 呼び出し元で emit_error + sys.exit(1) により処理する
 
 def main():
     parser = argparse.ArgumentParser(description='Run A/B test for LLM prompts.')
@@ -70,18 +87,17 @@ def main():
             config = json.load(f)
         logging(f"Loaded config from {args.config}", args.json)
     else:
-        logging(f"Error: Config file not found: {args.config}. Using default settings.", args.json)
-        # 設定ファイルが見つからない場合はエラーとするか、デフォルト設定を厳密に定義する
-        # 今回はエラーとして終了する
+        emit_error(f"Config file not found: {args.config}", args.json)
+        sys.exit(1)
 
     if not config.get("dynamic_prompt_ab_test_enabled", False):
-        logging("Error: 'dynamic_prompt_ab_test_enabled' is not true in config. Exiting.", args.json)
-        return
+        emit_error("'dynamic_prompt_ab_test_enabled' is not true in config.", args.json)
+        sys.exit(1)
 
     test_groups = config.get("test_groups", [])
     if not test_groups:
-        logging("Error: 'test_groups' not found or empty in config. Exiting.", args.json)
-        return
+        emit_error("'test_groups' not found or empty in config.", args.json)
+        sys.exit(1)
 
     evaluation_models = config.get("evaluation_models", ["llama3:8b", "llama3:8b"])
     if args.model1: # CLIオプションが指定されていれば上書き
@@ -96,15 +112,15 @@ def main():
         with open(evaluation_prompt_template_path, 'r', encoding='utf-8') as f:
             evaluation_prompt_template = f.read()
     else:
-        logging(f"Error: Evaluation prompt template not found at {evaluation_prompt_template_path}", args.json)
-        return
+        emit_error(f"Evaluation prompt template not found at {evaluation_prompt_template_path}", args.json)
+        sys.exit(1)
 
     all_results = {} # 全てのテスト結果を格納する辞書
 
     test_prompts = config.get("test_prompts", [])
     if not test_prompts:
-        logging("Error: 'test_prompts' not found or empty in config. Exiting.", args.json)
-        return
+        emit_error("'test_prompts' not found or empty in config.", args.json)
+        sys.exit(1)
 
     for test_prompt_data in test_prompts:
         prompt_id = test_prompt_data.get("id")
@@ -135,31 +151,39 @@ def main():
                     if not current_config_file or not current_workflow_id:
                         logging(f"Error: Static group '{group_id}' is missing 'prompt_file_path' or 'workflow_id'. Skipping.", args.json)
                         continue
-                    
-                    summary, log = run_llm_consultation(
-                        user_prompt, # ここで test_prompts から取得した user_prompt を使用
-                        evaluation_models[0],
-                        evaluation_models[1],
-                        workflow_id=current_workflow_id,
-                        prompt_file=current_config_file,
-                        prompt_language=group.get("prompt_language"),
-                        is_json=args.json
-                    )
+
+                    try:
+                        summary, log = run_llm_consultation(
+                            user_prompt, # ここで test_prompts から取得した user_prompt を使用
+                            evaluation_models[0],
+                            evaluation_models[1],
+                            workflow_id=current_workflow_id,
+                            prompt_file=current_config_file,
+                            prompt_language=group.get("prompt_language"),
+                            is_json=args.json
+                        )
+                    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+                        emit_error(f"LLM consultation failed: {e}", args.json)
+                        sys.exit(1)
                 elif group_type == "dynamic":
                     scenario_based_selection = group.get("scenario_based_workflow_selection_enabled", False)
-                    
+
                     if not scenario_based_selection:
                         logging(f"Error: Dynamic group '{group_id}' has 'scenario_based_workflow_selection_enabled' as false. Skipping.", args.json)
                         continue
-                    
-                    summary, log = run_llm_consultation(
-                        user_prompt, # ここで test_prompts から取得した user_prompt を使用
-                        evaluation_models[0], 
-                        evaluation_models[1],
-                        workflow_id=None, # index.js が解決
-                        prompt_language=group.get("prompt_language"),
-                        is_json=args.json
-                    )
+
+                    try:
+                        summary, log = run_llm_consultation(
+                            user_prompt, # ここで test_prompts から取得した user_prompt を使用
+                            evaluation_models[0],
+                            evaluation_models[1],
+                            workflow_id=None, # index.js が解決
+                            prompt_language=group.get("prompt_language"),
+                            is_json=args.json
+                        )
+                    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+                        emit_error(f"LLM consultation failed: {e}", args.json)
+                        sys.exit(1)
                 else:
                     logging(f"Error: Unknown group type '{group_type}' for group '{group_id}'. Skipping.", args.json)
                     continue

--- a/scripts/generate_reports.py
+++ b/scripts/generate_reports.py
@@ -97,13 +97,13 @@ def main():
         ab_test_result = subprocess.run(ab_test_runner_command, capture_output=True, text=True, check=True, env=os.environ)
         all_results = json.loads(ab_test_result.stdout)
     except subprocess.CalledProcessError as e:
-        print(f"Error: A/B test runner failed with exit code {e.returncode}", args.json)
-        print(f"Stdout:\n{e.stdout}", args.json)
-        print(f"Stderr:\n{e.stderr}", args.json)
+        emit_error(f"A/B test runner failed with exit code {e.returncode}", args.json)
+        logging(f"Stdout:\n{e.stdout}", args.json)
+        logging(f"Stderr:\n{e.stderr}", args.json)
         return
     except json.JSONDecodeError as e:
-        print(f"Error: Failed to parse A/B test results as JSON.", args.json)
-        print(f"Stdout:\n{ab_test_result.stdout}", args.json)
+        emit_error(f"Failed to parse A/B test results as JSON.", args.json)
+        logging(f"Stdout:\n{ab_test_result.stdout}", args.json)
         return
 
     report_content = "# A/Bテストレポート\n\n"

--- a/scripts/generate_reports.py
+++ b/scripts/generate_reports.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import json
 import re # 正規表現のために追加
+import sys
 from datetime import datetime
 import subprocess
 
@@ -100,11 +101,11 @@ def main():
         emit_error(f"A/B test runner failed with exit code {e.returncode}", args.json)
         logging(f"Stdout:\n{e.stdout}", args.json)
         logging(f"Stderr:\n{e.stderr}", args.json)
-        return
+        sys.exit(1)
     except json.JSONDecodeError as e:
         emit_error(f"Failed to parse A/B test results as JSON.", args.json)
         logging(f"Stdout:\n{ab_test_result.stdout}", args.json)
-        return
+        sys.exit(1)
 
     report_content = "# A/Bテストレポート\n\n"
     report_content += f"生成日時: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"

--- a/scripts/test_ab_test_runner.py
+++ b/scripts/test_ab_test_runner.py
@@ -1,0 +1,197 @@
+import builtins
+import io
+import json
+import subprocess
+import unittest
+from unittest.mock import MagicMock, patch
+
+from scripts.ab_test_runner import run_llm_consultation
+
+
+class TestRunLlmConsultation(unittest.TestCase):
+    """Tests for run_llm_consultation() to verify JSON-mode output purity."""
+
+    def _make_called_process_error(self, returncode=1, stdout="error output", stderr="stderr output"):
+        e = subprocess.CalledProcessError(returncode, ["node", "dist/index.js"])
+        e.stdout = stdout
+        e.stderr = stderr
+        return e
+
+    # -------------------------------------------------------------------------
+    # JSON モード: 成功ケース
+    # -------------------------------------------------------------------------
+    @patch("scripts.ab_test_runner.subprocess.run")
+    def test_json_mode_success(self, mock_run):
+        """JSON mode success: parsed values returned, nothing printed to stdout."""
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps({"finalOutput": "summary", "discussionLog": ["entry"]})
+        mock_run.return_value = mock_result
+
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            summary, log = run_llm_consultation("prompt", "m1", "m2", is_json=True)
+
+        self.assertEqual(summary, "summary")
+        self.assertEqual(log, ["entry"])
+        # JSON モードでは logging は stdout に出さない
+        self.assertEqual(mock_stdout.getvalue(), "")
+
+    # -------------------------------------------------------------------------
+    # JSON モード: subprocess.CalledProcessError
+    # -------------------------------------------------------------------------
+    @patch("scripts.ab_test_runner.subprocess.run")
+    def test_json_mode_subprocess_error_no_garbage(self, mock_run):
+        """JSON mode + CalledProcessError: re-raises, nothing printed to stdout."""
+        mock_run.side_effect = self._make_called_process_error()
+
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            with self.assertRaises(subprocess.CalledProcessError):
+                run_llm_consultation("prompt", "m1", "m2", is_json=True)
+
+        output = mock_stdout.getvalue()
+        self.assertNotIn("True", output)
+        self.assertEqual(output, "")
+
+    # -------------------------------------------------------------------------
+    # JSON モード: json.JSONDecodeError
+    # -------------------------------------------------------------------------
+    @patch("scripts.ab_test_runner.subprocess.run")
+    def test_json_mode_json_decode_error_no_garbage(self, mock_run):
+        """JSON mode + JSONDecodeError: re-raises, nothing printed to stdout."""
+        mock_result = MagicMock()
+        mock_result.stdout = "not valid json"
+        mock_run.return_value = mock_result
+
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            with self.assertRaises(json.JSONDecodeError):
+                run_llm_consultation("prompt", "m1", "m2", is_json=True)
+
+        output = mock_stdout.getvalue()
+        self.assertNotIn("True", output)
+        self.assertEqual(output, "")
+
+    # -------------------------------------------------------------------------
+    # 非 JSON モード: 成功ケース
+    # -------------------------------------------------------------------------
+    @patch("scripts.ab_test_runner.subprocess.run")
+    def test_non_json_mode_success(self, mock_run):
+        """Non-JSON mode success: 'Running command' log appears, no 'False' appended."""
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps({"finalOutput": "summary", "discussionLog": []})
+        mock_run.return_value = mock_result
+
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            summary, log = run_llm_consultation("prompt", "m1", "m2", is_json=False)
+
+        output = mock_stdout.getvalue()
+        self.assertEqual(summary, "summary")
+        self.assertEqual(log, [])
+        self.assertIn("Running command", output)
+        self.assertNotIn("False", output)
+
+    # -------------------------------------------------------------------------
+    # 非 JSON モード: subprocess.CalledProcessError
+    # -------------------------------------------------------------------------
+    @patch("scripts.ab_test_runner.subprocess.run")
+    def test_non_json_mode_subprocess_error_no_garbage(self, mock_run):
+        """Non-JSON mode + CalledProcessError: error message shown, 'False' NOT appended."""
+        mock_run.side_effect = self._make_called_process_error(returncode=1)
+
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            with self.assertRaises(subprocess.CalledProcessError):
+                run_llm_consultation("prompt", "m1", "m2", is_json=False)
+
+        output = mock_stdout.getvalue()
+        # エラーメッセージが表示されること
+        self.assertIn("Error", output)
+        # 現行バグ: print(msg, False) が "Error... False" を出力してしまう
+        self.assertNotIn("False", output)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestAbTestRunnerMainJson(unittest.TestCase):
+    """main() が JSON モードで正しいエラー JSON を出力することを検証する統合テスト。"""
+
+    BASE_CONFIG = {
+        "dynamic_prompt_ab_test_enabled": True,
+        "test_prompts": [
+            {"id": "p1", "user_prompt": "hello", "expected_scenario_id": "s1"}
+        ],
+        "test_groups": [
+            {
+                "id": "g1",
+                "type": "static",
+                "prompt_file_path": "prompts/foo.json",
+                "workflow_id": "wf1",
+                "prompt_language": "japanese",
+            }
+        ],
+        "evaluation_models": ["m1", "m2"],
+    }
+
+    def _make_open_side_effect(self, config_json: str, template: str = "tpl"):
+        """builtins.open のモック: パスに応じて config / template の内容を返す。
+        認識外のパス（gettext など）は実際の open に委譲する。
+        """
+        _real_open = builtins.open
+
+        def side_effect(path, *args, **kwargs):
+            path_str = str(path)
+            if "evaluation_prompt_template" in path_str:
+                content = template
+            elif path_str.endswith(".json") or "config" in path_str:
+                content = config_json
+            else:
+                return _real_open(path, *args, **kwargs)
+            m = MagicMock()
+            m.__enter__ = MagicMock(return_value=io.StringIO(content))
+            m.__exit__ = MagicMock(return_value=False)
+            return m
+
+        return side_effect
+
+    def _run_main_json(self, subproc_side_effect=None, config_exists=True):
+        """JSON モードで main() を実行し、(stdout出力, 終了コード) を返す。"""
+        config_json = json.dumps(self.BASE_CONFIG)
+
+        def mock_exists(path):
+            if "evaluation_prompt_template" in str(path):
+                return True
+            return config_exists
+
+        with patch("scripts.ab_test_runner.os.path.exists", side_effect=mock_exists), \
+             patch("builtins.open", side_effect=self._make_open_side_effect(config_json)), \
+             patch("scripts.ab_test_runner.subprocess.run", side_effect=subproc_side_effect), \
+             patch("sys.argv", ["ab.py", "hello", "--json", "--config", "config.json"]):
+            captured = io.StringIO()
+            with patch("sys.stdout", captured):
+                try:
+                    from scripts.ab_test_runner import main
+                    main()
+                    return captured.getvalue(), None
+                except SystemExit as e:
+                    return captured.getvalue(), e.code
+
+    def test_json_mode_subprocess_error_emits_error_json(self):
+        """main() + --json + CalledProcessError → {"error": {...}} が stdout に出力され exit 1。"""
+        err = subprocess.CalledProcessError(1, ["node"], output="", stderr="err")
+        output, exit_code = self._run_main_json(subproc_side_effect=err)
+
+        self.assertEqual(exit_code, 1, "終了コードが 1 でなければならない")
+        output = output.strip()
+        self.assertTrue(len(output) > 0, "JSON モードのエラー時に stdout が空")
+        parsed = json.loads(output)  # 有効な JSON でなければ ValueError
+        self.assertIn("error", parsed)
+
+    def test_json_mode_missing_config_emits_error_json(self):
+        """main() + --json + 設定ファイル不在 → {"error": {...}} が stdout に出力され非0終了。"""
+        output, exit_code = self._run_main_json(config_exists=False)
+
+        self.assertIsNotNone(exit_code, "SystemExit が発生しなかった")
+        self.assertNotEqual(exit_code, 0, "終了コードが 0 であってはならない")
+        output = output.strip()
+        self.assertTrue(len(output) > 0, "JSON モードのエラー時に stdout が空")
+        parsed = json.loads(output)
+        self.assertIn("error", parsed)

--- a/scripts/test_ab_test_runner.py
+++ b/scripts/test_ab_test_runner.py
@@ -107,10 +107,6 @@ class TestRunLlmConsultation(unittest.TestCase):
         self.assertNotIn("False", output)
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestAbTestRunnerMainJson(unittest.TestCase):
     """main() が JSON モードで正しいエラー JSON を出力することを検証する統合テスト。"""
 
@@ -195,3 +191,7 @@ class TestAbTestRunnerMainJson(unittest.TestCase):
         self.assertTrue(len(output) > 0, "JSON モードのエラー時に stdout が空")
         parsed = json.loads(output)
         self.assertIn("error", parsed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

   `scripts/ab_test_runner.py` の例外処理で `print(msg, is_json)`
  と誤って記述されていたため、`--json` モード時に `is_json` の値（`True`/`False`）が
  stdout に混入し、下流の `generate_reports.py` での JSON パースが壊れていた。同種バグが
   `generate_reports.py` にも5箇所存在した。

   本 PR では `emit_error()` を追加して JSON モード時のエラー出力を統一し、テストで
  stdout 汚染がないことを保証する。

   Closes #114

   ## 変更ファイル

   | ファイル | 種別 | 内容 |
   |---------|------|------|
   | `scripts/ab_test_runner.py` | 修正 | `emit_error()` 追加、例外 re-raise
  化、プリフライトを `emit_error()+sys.exit(1)` に統一 |
   | `scripts/generate_reports.py` | 修正 | `print(..., is_json)` 5箇所を
  `emit_error()`/`logging()` に置換 |
   | `scripts/test_ab_test_runner.py` | 新規 | 単体5件 + 統合2件 |

   ## 主な変更点

   - **`emit_error(message, is_json)`** を追加。JSON モード時は `{"error": {"message":
  "..."}}` を stdout に出力し、非 JSON モードは `logging()` 経由のテキスト出力にする。
   - **`run_llm_consultation()`** はエラー時に例外を飲み込まず re-raise し、呼び出し元
  `main()` が `try/except` で保護して `emit_error()+sys.exit(1)` を呼ぶ設計に変更。
   - **プリフライト検証**（設定ファイル不在・必須フラグ未設定・テンプレート不在）を
  `logging()+return` から `emit_error()+sys.exit(1)` に統一し、JSON
  モードで無出力のまま終了コード 0 で失敗していた問題を修正。

   ## テスト

   ```bash
   python3 -m pytest scripts/ -v
   # → 14 passed（既存 7件 + 新規 7件）

  注意点

   - LLM 呼び出しが1回でも失敗すると即 sys.exit(1)
  するため、ループ途中の部分結果は返さない仕様に変わっている。
   - emit_error() が ab_test_runner.py と generate_reports.py
  の両方に定義されている（DRY 違反）が、共通モジュール化は別 Issue で対応予定。