### PR TITLE
feat: add cli wrapper project context detection

### DIFF
--- a/checkpoint/2026-03-22__multi-llm-agent-cli-poc__ISSUE-160.md
+++ b/checkpoint/2026-03-22__multi-llm-agent-cli-poc__ISSUE-160.md
@@ -3,3 +3,7 @@
 - 02:22 [fix] act: PR #165 のレビュー指摘を取得し、ProjectContext の設定値 trim・JSON 解析エラー文脈付与・README 表記ずれを修正して push した
   evd: gh api repos/aoitan/multi-llm-agent-cli-poc/pulls/165/comments; npm test -- --runTestsByPath experiment/cli_wrapper/context.test.ts; commit: e99ebd4
   block: なし
+
+- 02:31 [fix] act: PR #165 の再レビュー指摘を取得し、設定読込の read/parse エラー切り分け・README の backend 優先順追記・Copilot CLI 記録のパス一般化を修正して push した
+  evd: gh api repos/aoitan/multi-llm-agent-cli-poc/pulls/165/comments; npm test -- --runTestsByPath experiment/cli_wrapper/context.test.ts; commit: 2c3a6af
+  block: なし

--- a/checkpoint/2026-03-22__multi-llm-agent-cli-poc__ISSUE-160.md
+++ b/checkpoint/2026-03-22__multi-llm-agent-cli-poc__ISSUE-160.md
@@ -1,0 +1,5 @@
+# Timeline
+
+- 02:22 [fix] act: PR #165 のレビュー指摘を取得し、ProjectContext の設定値 trim・JSON 解析エラー文脈付与・README 表記ずれを修正して push した
+  evd: gh api repos/aoitan/multi-llm-agent-cli-poc/pulls/165/comments; npm test -- --runTestsByPath experiment/cli_wrapper/context.test.ts; commit: e99ebd4
+  block: なし

--- a/experiment/cli_wrapper/README.md
+++ b/experiment/cli_wrapper/README.md
@@ -61,7 +61,7 @@ Phase 1 で対象とする CLI ツール：
 - `experiment/cli_wrapper/`：本ディレクトリ。CLI ラッパーの実験用 PoC 領域。
 - `src/`：本番実装領域。PoC で得られた知見を反映したコードを配置。
 - `scripts/`：共通ユーティリティや CI 用スクリプト。
-- 他の `experiments/*/`：他実験領域とは責務を明確に分離。
+- 他の `experiment/*/`：他実験領域とは責務を明確に分離。
 
 ## 関連 Issue
 

--- a/experiment/cli_wrapper/README.md
+++ b/experiment/cli_wrapper/README.md
@@ -44,7 +44,7 @@ Phase 1 で対象とする CLI ツール：
 ```
 
 - `id`: 任意。`projectId` を上書きする。未指定時は git root のディレクトリ名を使う。
-- `backend`: 任意。既定値は `copilot`。
+- `backend`: 任意。.cli-wrapper.json にも `detectProjectContext()` の `options.backend` にも指定がない場合の既定値は `copilot`。
 - `envType`: 任意。`prod` / `staging` / `dev` / `unknown` のいずれか。
 - `dangerLevel`: 任意。`high` / `normal` のいずれか。
 
@@ -52,7 +52,7 @@ Phase 1 で対象とする CLI ツール：
 
 - `projectId`: `.cli-wrapper.json` の `id` があればそれを使い、なければ git root basename を使う。
 - `cwd`: `detectProjectContext()` に渡したカレントディレクトリをそのまま保持する。
-- `backend`: `.cli-wrapper.json` の `backend` があればそれを使い、なければ `copilot`。
+- `backend`: `.cli-wrapper.json` の `backend` があればそれを最優先で使い、なければ `detectProjectContext()` に渡された `options.backend` を使い、いずれも無ければ `copilot` を既定値とする。
 - `envType`: `NODE_ENV` / `RAILS_ENV` / `RACK_ENV` / `APP_ENV` を優先順で見て `prod` / `staging` / `dev` / `unknown` に正規化する。
 - `dangerLevel`: git branch が `main` / `master` / `production` / `prod` の場合は `high`、それ以外は `normal`。`.cli-wrapper.json` があればその値を優先する。
 

--- a/experiment/cli_wrapper/README.md
+++ b/experiment/cli_wrapper/README.md
@@ -1,4 +1,4 @@
-# CLI Wrapper (experiments/cli_wrapper)
+# CLI Wrapper (`experiment/cli_wrapper`)
 
 ## 目的
 
@@ -25,11 +25,40 @@
 
 Phase 1 で対象とする CLI ツール：
 - GitHub Copilot CLI
-  - 選定記録: `experiment/cli_wrapper/target_cli_copilot.md`
+  - 選定記録: [`target_cli_copilot.md`](./target_cli_copilot.md)
+  - 起動コマンド: `copilot` / `gh copilot`
+
+## ProjectContext 設定
+
+`context.ts` は git root と環境変数から `ProjectContext` を検出する。必要に応じて、プロジェクトルートに `.cli-wrapper.json` を置くことで検出結果を明示上書きできる。
+
+### `.cli-wrapper.json` スキーマ
+
+```json
+{
+  "id": "my-project",
+  "backend": "copilot",
+  "envType": "staging",
+  "dangerLevel": "normal"
+}
+```
+
+- `id`: 任意。`projectId` を上書きする。未指定時は git root のディレクトリ名を使う。
+- `backend`: 任意。既定値は `copilot`。
+- `envType`: 任意。`prod` / `staging` / `dev` / `unknown` のいずれか。
+- `dangerLevel`: 任意。`high` / `normal` のいずれか。
+
+### 検出ルール
+
+- `projectId`: `.cli-wrapper.json` の `id` があればそれを使い、なければ git root basename を使う。
+- `cwd`: `detectProjectContext()` に渡したカレントディレクトリをそのまま保持する。
+- `backend`: `.cli-wrapper.json` の `backend` があればそれを使い、なければ `copilot`。
+- `envType`: `NODE_ENV` / `RAILS_ENV` / `RACK_ENV` / `APP_ENV` を優先順で見て `prod` / `staging` / `dev` / `unknown` に正規化する。
+- `dangerLevel`: git branch が `main` / `master` / `production` / `prod` の場合は `high`、それ以外は `normal`。`.cli-wrapper.json` があればその値を優先する。
 
 ## ディレクトリ責務
 
-- `experiments/cli_wrapper/`：本ディレクトリ。CLI ラッパーの実験用 PoC 領域。
+- `experiment/cli_wrapper/`：本ディレクトリ。CLI ラッパーの実験用 PoC 領域。
 - `src/`：本番実装領域。PoC で得られた知見を反映したコードを配置。
 - `scripts/`：共通ユーティリティや CI 用スクリプト。
 - 他の `experiments/*/`：他実験領域とは責務を明確に分離。
@@ -37,4 +66,5 @@ Phase 1 で対象とする CLI ツール：
 ## 関連 Issue
 
 - CW-1 (#133)：CLI Wrapper に関する Issue
-- #141：experiments/cli_wrapper/ ディレクトリ作成と README 記述
+- #141：`experiment/cli_wrapper/` ディレクトリ作成と README 記述
+- #142：GitHub Copilot CLI の選定と記録

--- a/experiment/cli_wrapper/context.test.ts
+++ b/experiment/cli_wrapper/context.test.ts
@@ -1,0 +1,113 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { createTestTempDir, cleanupTestTempDir } from '../../src/testHelpers/testTempDir';
+import { detectProjectContext, type ProjectContext } from './context';
+
+function initGitRepo(repoDir: string, branchName = 'feature/test'): void {
+  execFileSync('git', ['init'], { cwd: repoDir, stdio: 'pipe' });
+  execFileSync('git', ['checkout', '-b', branchName], { cwd: repoDir, stdio: 'pipe' });
+}
+
+describe('detectProjectContext', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTestTempDir('cli-wrapper-context-');
+  });
+
+  afterEach(() => {
+    cleanupTestTempDir(tempDir);
+  });
+
+  it('detects projectId from git root basename and defaults to normal danger', () => {
+    const repoDir = path.join(tempDir, 'sample-project');
+    fs.mkdirSync(repoDir);
+    initGitRepo(repoDir, 'feature/context');
+
+    const nestedDir = path.join(repoDir, 'packages', 'app');
+    fs.mkdirSync(nestedDir, { recursive: true });
+
+    const context = detectProjectContext({ cwd: nestedDir, env: {} });
+
+    expect(context).toEqual<ProjectContext>({
+      projectId: 'sample-project',
+      cwd: nestedDir,
+      backend: 'copilot',
+      envType: 'unknown',
+      dangerLevel: 'normal',
+    });
+  });
+
+  it('maps NODE_ENV and RAILS_ENV values to envType', () => {
+    const repoDir = path.join(tempDir, 'env-project');
+    fs.mkdirSync(repoDir);
+    initGitRepo(repoDir, 'feature/context');
+
+    expect(
+      detectProjectContext({
+        cwd: repoDir,
+        env: { NODE_ENV: 'production' },
+      }).envType
+    ).toBe('prod');
+
+    expect(
+      detectProjectContext({
+        cwd: repoDir,
+        env: { RAILS_ENV: 'staging' },
+      }).envType
+    ).toBe('staging');
+
+    expect(
+      detectProjectContext({
+        cwd: repoDir,
+        env: { NODE_ENV: 'development' },
+      }).envType
+    ).toBe('dev');
+  });
+
+  it('marks main and production branches as high danger', () => {
+    const mainRepoDir = path.join(tempDir, 'main-project');
+    fs.mkdirSync(mainRepoDir);
+    initGitRepo(mainRepoDir, 'main');
+
+    const productionRepoDir = path.join(tempDir, 'production-project');
+    fs.mkdirSync(productionRepoDir);
+    initGitRepo(productionRepoDir, 'production');
+
+    expect(detectProjectContext({ cwd: mainRepoDir }).dangerLevel).toBe('high');
+    expect(detectProjectContext({ cwd: productionRepoDir }).dangerLevel).toBe('high');
+  });
+
+  it('allows .cli-wrapper.json to override detected values', () => {
+    const repoDir = path.join(tempDir, 'override-project');
+    fs.mkdirSync(repoDir);
+    initGitRepo(repoDir, 'main');
+    const nestedDir = path.join(repoDir, 'nested');
+    fs.mkdirSync(nestedDir);
+
+    fs.writeFileSync(
+      path.join(repoDir, '.cli-wrapper.json'),
+      JSON.stringify(
+        {
+          id: 'custom-project',
+          backend: 'custom-backend',
+          envType: 'staging',
+          dangerLevel: 'normal',
+        },
+        null,
+        2
+      )
+    );
+
+    const context = detectProjectContext({
+      cwd: nestedDir,
+      env: { NODE_ENV: 'production' },
+    });
+
+    expect(context.projectId).toBe('custom-project');
+    expect(context.backend).toBe('custom-backend');
+    expect(context.envType).toBe('staging');
+    expect(context.dangerLevel).toBe('normal');
+  });
+});

--- a/experiment/cli_wrapper/context.test.ts
+++ b/experiment/cli_wrapper/context.test.ts
@@ -137,10 +137,9 @@ describe('detectProjectContext', () => {
 
     const configPath = path.join(repoDir, '.cli-wrapper.json');
     fs.writeFileSync(configPath, '{ invalid json');
-    const resolvedConfigPath = fs.realpathSync(configPath);
 
     expect(() => detectProjectContext({ cwd: repoDir, env: {} })).toThrow(
-      `Failed to parse ${resolvedConfigPath}:`
+      /Failed to parse .*\.cli-wrapper\.json:/
     );
   });
 });

--- a/experiment/cli_wrapper/context.test.ts
+++ b/experiment/cli_wrapper/context.test.ts
@@ -110,4 +110,37 @@ describe('detectProjectContext', () => {
     expect(context.envType).toBe('staging');
     expect(context.dangerLevel).toBe('normal');
   });
+
+  it('trims overridden id and backend values from .cli-wrapper.json', () => {
+    const repoDir = path.join(tempDir, 'trimmed-project');
+    fs.mkdirSync(repoDir);
+    initGitRepo(repoDir, 'feature/context');
+
+    fs.writeFileSync(
+      path.join(repoDir, '.cli-wrapper.json'),
+      JSON.stringify({
+        id: '  custom-project  ',
+        backend: '  copilot-proxy  ',
+      })
+    );
+
+    const context = detectProjectContext({ cwd: repoDir, env: {} });
+
+    expect(context.projectId).toBe('custom-project');
+    expect(context.backend).toBe('copilot-proxy');
+  });
+
+  it('wraps invalid .cli-wrapper.json parse errors with the config path', () => {
+    const repoDir = path.join(tempDir, 'broken-config-project');
+    fs.mkdirSync(repoDir);
+    initGitRepo(repoDir, 'feature/context');
+
+    const configPath = path.join(repoDir, '.cli-wrapper.json');
+    fs.writeFileSync(configPath, '{ invalid json');
+    const resolvedConfigPath = fs.realpathSync(configPath);
+
+    expect(() => detectProjectContext({ cwd: repoDir, env: {} })).toThrow(
+      `Failed to parse ${resolvedConfigPath}:`
+    );
+  });
 });

--- a/experiment/cli_wrapper/context.ts
+++ b/experiment/cli_wrapper/context.ts
@@ -135,9 +135,18 @@ function loadCliWrapperConfig(projectRoot: string): CliWrapperConfig {
     return {};
   }
 
+  let rawConfig: string;
+  try {
+    rawConfig = fs.readFileSync(configPath, 'utf8');
+  } catch (err) {
+    throw new Error(
+      `Failed to read ${configPath}: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+
   let parsed: unknown;
   try {
-    parsed = JSON.parse(fs.readFileSync(configPath, 'utf8')) as unknown;
+    parsed = JSON.parse(rawConfig) as unknown;
   } catch (err) {
     throw new Error(
       `Failed to parse ${configPath}: ${err instanceof Error ? err.message : String(err)}`

--- a/experiment/cli_wrapper/context.ts
+++ b/experiment/cli_wrapper/context.ts
@@ -100,11 +100,20 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function assertEnvType(value: unknown, fieldName: string): EnvType {
-  if (value === undefined) {
-    return 'unknown';
+function assertNonEmptyString(value: unknown, fieldName: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`Invalid ${fieldName} in .cli-wrapper.json: ${String(value)}`);
   }
 
+  const trimmed = value.trim();
+  if (trimmed === '') {
+    throw new Error(`Invalid ${fieldName} in .cli-wrapper.json: ${String(value)}`);
+  }
+
+  return trimmed;
+}
+
+function assertEnvType(value: unknown, fieldName: string): EnvType {
   if (value === 'prod' || value === 'staging' || value === 'dev' || value === 'unknown') {
     return value;
   }
@@ -126,25 +135,27 @@ function loadCliWrapperConfig(projectRoot: string): CliWrapperConfig {
     return {};
   }
 
-  const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8')) as unknown;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(configPath, 'utf8')) as unknown;
+  } catch (err) {
+    throw new Error(
+      `Failed to parse ${configPath}: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+
   if (!isRecord(parsed)) {
-    throw new Error('.cli-wrapper.json must contain a JSON object');
+    throw new Error(`${configPath} must contain a JSON object`);
   }
 
   const config: CliWrapperConfig = {};
 
   if (parsed.id !== undefined) {
-    if (typeof parsed.id !== 'string' || parsed.id.trim() === '') {
-      throw new Error(`Invalid id in .cli-wrapper.json: ${String(parsed.id)}`);
-    }
-    config.id = parsed.id;
+    config.id = assertNonEmptyString(parsed.id, 'id');
   }
 
   if (parsed.backend !== undefined) {
-    if (typeof parsed.backend !== 'string' || parsed.backend.trim() === '') {
-      throw new Error(`Invalid backend in .cli-wrapper.json: ${String(parsed.backend)}`);
-    }
-    config.backend = parsed.backend;
+    config.backend = assertNonEmptyString(parsed.backend, 'backend');
   }
 
   if (parsed.envType !== undefined) {

--- a/experiment/cli_wrapper/context.ts
+++ b/experiment/cli_wrapper/context.ts
@@ -1,0 +1,178 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+
+export type EnvType = 'prod' | 'staging' | 'dev' | 'unknown';
+export type DangerLevel = 'high' | 'normal';
+
+export interface ProjectContext {
+  projectId: string;
+  cwd: string;
+  backend: string;
+  envType: EnvType;
+  dangerLevel: DangerLevel;
+}
+
+export interface CliWrapperConfig {
+  id?: string;
+  backend?: string;
+  envType?: EnvType;
+  dangerLevel?: DangerLevel;
+}
+
+export interface DetectProjectContextOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  backend?: string;
+}
+
+const ENV_KEYS = ['NODE_ENV', 'RAILS_ENV', 'RACK_ENV', 'APP_ENV'] as const;
+const HIGH_DANGER_BRANCHES = new Set(['main', 'master', 'production', 'prod']);
+
+function runGitCommand(args: string[], cwd: string): string | null {
+  try {
+    return execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function detectGitRoot(cwd: string): string | null {
+  const gitRoot = runGitCommand(['rev-parse', '--show-toplevel'], cwd);
+  return gitRoot ? path.resolve(gitRoot) : null;
+}
+
+function detectGitBranch(cwd: string): string | null {
+  const branch = runGitCommand(['branch', '--show-current'], cwd);
+  return branch || null;
+}
+
+function normalizeEnvType(value: string | undefined): EnvType {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) {
+    return 'unknown';
+  }
+
+  if (normalized === 'production' || normalized === 'prod') {
+    return 'prod';
+  }
+
+  if (normalized === 'staging' || normalized === 'stage' || normalized === 'stg') {
+    return 'staging';
+  }
+
+  if (
+    normalized === 'development' ||
+    normalized === 'dev' ||
+    normalized === 'test' ||
+    normalized === 'local'
+  ) {
+    return 'dev';
+  }
+
+  return 'unknown';
+}
+
+function detectEnvType(env: NodeJS.ProcessEnv): EnvType {
+  for (const key of ENV_KEYS) {
+    const envType = normalizeEnvType(env[key]);
+    if (envType !== 'unknown') {
+      return envType;
+    }
+  }
+
+  return 'unknown';
+}
+
+function detectDangerLevel(branch: string | null): DangerLevel {
+  if (!branch) {
+    return 'normal';
+  }
+
+  return HIGH_DANGER_BRANCHES.has(branch.toLowerCase()) ? 'high' : 'normal';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function assertEnvType(value: unknown, fieldName: string): EnvType {
+  if (value === undefined) {
+    return 'unknown';
+  }
+
+  if (value === 'prod' || value === 'staging' || value === 'dev' || value === 'unknown') {
+    return value;
+  }
+
+  throw new Error(`Invalid ${fieldName} in .cli-wrapper.json: ${String(value)}`);
+}
+
+function assertDangerLevel(value: unknown): DangerLevel {
+  if (value === 'high' || value === 'normal') {
+    return value;
+  }
+
+  throw new Error(`Invalid dangerLevel in .cli-wrapper.json: ${String(value)}`);
+}
+
+function loadCliWrapperConfig(projectRoot: string): CliWrapperConfig {
+  const configPath = path.join(projectRoot, '.cli-wrapper.json');
+  if (!fs.existsSync(configPath)) {
+    return {};
+  }
+
+  const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8')) as unknown;
+  if (!isRecord(parsed)) {
+    throw new Error('.cli-wrapper.json must contain a JSON object');
+  }
+
+  const config: CliWrapperConfig = {};
+
+  if (parsed.id !== undefined) {
+    if (typeof parsed.id !== 'string' || parsed.id.trim() === '') {
+      throw new Error(`Invalid id in .cli-wrapper.json: ${String(parsed.id)}`);
+    }
+    config.id = parsed.id;
+  }
+
+  if (parsed.backend !== undefined) {
+    if (typeof parsed.backend !== 'string' || parsed.backend.trim() === '') {
+      throw new Error(`Invalid backend in .cli-wrapper.json: ${String(parsed.backend)}`);
+    }
+    config.backend = parsed.backend;
+  }
+
+  if (parsed.envType !== undefined) {
+    config.envType = assertEnvType(parsed.envType, 'envType');
+  }
+
+  if (parsed.dangerLevel !== undefined) {
+    config.dangerLevel = assertDangerLevel(parsed.dangerLevel);
+  }
+
+  return config;
+}
+
+export function detectProjectContext(
+  options: DetectProjectContextOptions = {}
+): ProjectContext {
+  const cwd = path.resolve(options.cwd ?? process.cwd());
+  const env = options.env ?? process.env;
+  const gitRoot = detectGitRoot(cwd);
+  const projectRoot = gitRoot ?? cwd;
+  const branch = gitRoot ? detectGitBranch(cwd) : null;
+  const config = loadCliWrapperConfig(projectRoot);
+
+  return {
+    projectId: config.id ?? path.basename(projectRoot),
+    cwd,
+    backend: config.backend ?? options.backend ?? 'copilot',
+    envType: config.envType ?? detectEnvType(env),
+    dangerLevel: config.dangerLevel ?? detectDangerLevel(branch),
+  };
+}

--- a/experiment/cli_wrapper/target_cli_copilot.md
+++ b/experiment/cli_wrapper/target_cli_copilot.md
@@ -16,7 +16,7 @@
 
 - 観測日: 2026-03-17
 - インストール確認:
-  - `which copilot` -> `/Users/aoitan/.nvm/versions/node/v22.18.0/bin/copilot`
+  - `which copilot` -> `<HOME>/.nvm/versions/node/v22.18.0/bin/copilot`
   - `npm list -g --depth=0` -> `@github/copilot@0.0.372`
 - バージョン確認方法:
   - 優先: `copilot --version`

--- a/experiment/cli_wrapper/target_cli_copilot.md
+++ b/experiment/cli_wrapper/target_cli_copilot.md
@@ -4,6 +4,7 @@
 
 - CLI 名: GitHub Copilot CLI
 - 実行コマンド: `copilot`（または `gh copilot`）
+- 記録対象: 選定理由、バージョン確認結果、起動方法、PTY 挙動の初期観測
 
 ## 選定理由
 
@@ -17,6 +18,9 @@
 - インストール確認:
   - `which copilot` -> `/Users/aoitan/.nvm/versions/node/v22.18.0/bin/copilot`
   - `npm list -g --depth=0` -> `@github/copilot@0.0.372`
+- バージョン確認方法:
+  - 優先: `copilot --version`
+  - 補助: `npm list -g --depth=0`
 - `copilot --version` の実行結果:
   - `ERROR: SecItemCopyMatching failed -50`
   - 現時点ではコマンド出力からバージョン文字列を直接取得できていない。
@@ -40,3 +44,4 @@
 ## 備考
 
 - 本メモは Issue #142 の初期記録。詳細な PTY 観測（逐次トークン出力、SIGINT/SIGTERM 応答、終了コード分類）は別タスクで拡張する。
+- Issue #142 の受け入れ条件にある「選定理由」「バージョンと起動コマンド」「対象 CLI の記録」は本ファイルで充足する。


### PR DESCRIPTION
## 概要 (Summary)
CLI Wrapper PoC 向けに ProjectContext 検出ロジックを追加し、環境変数・git branch・.cli-wrapper.json による判定と上書きを実装しました。あわせて README を更新し、#142 で追加した対象 CLI ドキュメントの導線と記載要件も補強しています。

## 関連Issue (Related Issues)
Closes #160
Refs #142

## 変更の種類 (Type of Change)
- [x] 新機能 (New feature)
- [ ] バグ修正 (Bug fix)
- [ ] リファクタリング (Refactoring)
- [x] ドキュメント更新 (Documentation)

## 詳細な変更点 (Detailed Changes)
- experiment/cli_wrapper/context.ts: ProjectContext 型と検出ロジックを追加。git root basename、環境変数、危険ブランチ、.cli-wrapper.json 上書きに対応。
- experiment/cli_wrapper/context.test.ts: 一時 git リポジトリを使ったユニットテストを追加し、envType、dangerLevel、override を検証。
- experiment/cli_wrapper/README.md: .cli-wrapper.json スキーマと検出ルールを追記し、CLI Wrapper ディレクトリ表記と選定記録リンクも整理。
- experiment/cli_wrapper/target_cli_copilot.md: #142 の受け入れ条件に対応する記録対象とバージョン確認方法の明記を追加。

## 動作確認手順 (Verification Steps)
1. npm test -- --runTestsByPath experiment/cli_wrapper/context.test.ts
2. experiment/cli_wrapper/README.md を開き、.cli-wrapper.json のスキーマと検出ルールが確認できること
3. experiment/cli_wrapper/target_cli_copilot.md を開き、選定理由・バージョン確認方法・起動コマンドが記載されていること

## 自己チェック (Self Check)
- [x] 既存のテストを壊していないか
- [x] 機密情報（API Key等）が含まれていないか